### PR TITLE
feat: add PDF to Markdown conversion tool

### DIFF
--- a/app/tools/[toolId]/page.tsx
+++ b/app/tools/[toolId]/page.tsx
@@ -47,6 +47,7 @@ const toolComponents: Record<string, React.ComponentType> = {
   "time-calc": dynamic(() => import("@/components/tools/time-calc").then(mod => mod.TimeCalcTool)),
   "unit-converter": dynamic(() => import("@/components/tools/unit-converter").then(mod => mod.UnitConverterTool)),
   "encoder": dynamic(() => import("@/components/tools/encoder").then(mod => mod.EncoderTool)),
+  "pdf-to-markdown": dynamic(() => import("@/components/tools/pdf-to-markdown").then(mod => mod.PdfToMarkdownTool)),
 };
 
 interface ToolPageProps {

--- a/components/tools/pdf-to-markdown.tsx
+++ b/components/tools/pdf-to-markdown.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import { Upload, Download, Copy, Check, FileText, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import {
+  convertPdfToMarkdown,
+  ConversionOptions,
+  ConversionStats,
+} from "@/lib/pdf-to-markdown";
+
+export function PdfToMarkdownTool() {
+  const [file, setFile] = useState<File | null>(null);
+  const [markdown, setMarkdown] = useState<string>("");
+  const [stats, setStats] = useState<ConversionStats | null>(null);
+  const [isConverting, setIsConverting] = useState(false);
+  const [progress, setProgress] = useState({ current: 0, total: 0 });
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Options
+  const [headingSensitivity, setHeadingSensitivity] = useState<
+    ConversionOptions["headingSensitivity"]
+  >("medium");
+  const [detectLists, setDetectLists] = useState(true);
+  const [addPageBreaks, setAddPageBreaks] = useState(true);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileSelect = useCallback(
+    async (selectedFile: File) => {
+      if (!selectedFile.type.includes("pdf")) {
+        setError("Please select a PDF file");
+        return;
+      }
+
+      setFile(selectedFile);
+      setError(null);
+      setIsConverting(true);
+      setProgress({ current: 0, total: 0 });
+
+      try {
+        const arrayBuffer = await selectedFile.arrayBuffer();
+        const result = await convertPdfToMarkdown(
+          arrayBuffer,
+          {
+            headingSensitivity,
+            detectLists,
+            addPageBreaks,
+          },
+          (current, total) => {
+            setProgress({ current, total });
+          }
+        );
+
+        setMarkdown(result.markdown);
+        setStats(result.stats);
+      } catch (err) {
+        console.error("PDF conversion failed:", err);
+        setError(
+          err instanceof Error ? err.message : "Failed to convert PDF"
+        );
+        setMarkdown("");
+        setStats(null);
+      } finally {
+        setIsConverting(false);
+      }
+    },
+    [headingSensitivity, detectLists, addPageBreaks]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const droppedFile = e.dataTransfer.files[0];
+      if (droppedFile) {
+        handleFileSelect(droppedFile);
+      }
+    },
+    [handleFileSelect]
+  );
+
+  const handleFileInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const selectedFile = e.target.files?.[0];
+      if (selectedFile) {
+        handleFileSelect(selectedFile);
+      }
+    },
+    [handleFileSelect]
+  );
+
+  const reconvert = useCallback(async () => {
+    if (!file) return;
+    handleFileSelect(file);
+  }, [file, handleFileSelect]);
+
+  const copyToClipboard = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  }, [markdown]);
+
+  const downloadMarkdown = useCallback(() => {
+    const blob = new Blob([markdown], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    const baseName = file?.name.replace(/\.pdf$/i, "") || "document";
+    link.download = `${baseName}.md`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }, [markdown, file]);
+
+  const clearFile = useCallback(() => {
+    setFile(null);
+    setMarkdown("");
+    setStats(null);
+    setError(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      {/* Options Panel */}
+      <div className="flex flex-wrap gap-6 items-end p-4 bg-muted/50 rounded-lg">
+        <div className="space-y-2">
+          <Label className="font-bold">Heading Detection</Label>
+          <Select
+            value={headingSensitivity}
+            onValueChange={(v) =>
+              setHeadingSensitivity(v as ConversionOptions["headingSensitivity"])
+            }
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="low">Low (larger text)</SelectItem>
+              <SelectItem value="medium">Medium</SelectItem>
+              <SelectItem value="high">High (subtle)</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center gap-3 h-10">
+          <Switch
+            id="detect-lists"
+            checked={detectLists}
+            onCheckedChange={setDetectLists}
+          />
+          <Label htmlFor="detect-lists" className="cursor-pointer">
+            Detect lists
+          </Label>
+        </div>
+
+        <div className="flex items-center gap-3 h-10">
+          <Switch
+            id="page-breaks"
+            checked={addPageBreaks}
+            onCheckedChange={setAddPageBreaks}
+          />
+          <Label htmlFor="page-breaks" className="cursor-pointer">
+            Page breaks
+          </Label>
+        </div>
+
+        {file && (
+          <Button
+            variant="outline"
+            onClick={reconvert}
+            disabled={isConverting}
+            className="ml-auto"
+          >
+            Re-convert
+          </Button>
+        )}
+      </div>
+
+      {/* Upload Zone */}
+      {!file && (
+        <div
+          onDrop={handleDrop}
+          onDragOver={(e) => e.preventDefault()}
+          onClick={() => fileInputRef.current?.click()}
+          className={cn(
+            "border-2 border-dashed rounded-xl p-12 text-center transition-colors cursor-pointer",
+            "hover:border-primary/50 hover:bg-muted/30",
+            error && "border-destructive"
+          )}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".pdf,application/pdf"
+            className="hidden"
+            onChange={handleFileInputChange}
+          />
+          <Upload className="size-12 mx-auto text-muted-foreground mb-4" />
+          <p className="font-medium text-lg">Drop a PDF here</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            or click to select a file
+          </p>
+          {error && (
+            <p className="text-sm text-destructive mt-4">{error}</p>
+          )}
+        </div>
+      )}
+
+      {/* Converting Progress */}
+      {isConverting && (
+        <div className="flex flex-col items-center justify-center py-12 gap-4">
+          <Loader2 className="size-10 animate-spin text-primary" />
+          <p className="text-muted-foreground">
+            Converting page {progress.current} of {progress.total}...
+          </p>
+        </div>
+      )}
+
+      {/* Results */}
+      {file && !isConverting && markdown && (
+        <div className="space-y-4">
+          {/* File Info & Stats */}
+          <div className="flex flex-wrap items-center gap-4 p-4 bg-muted/50 rounded-lg">
+            <div className="flex items-center gap-3">
+              <FileText className="size-5 text-muted-foreground" />
+              <span className="font-medium">{file.name}</span>
+            </div>
+
+            {stats && (
+              <div className="flex flex-wrap gap-4 text-sm text-muted-foreground ml-auto">
+                <span>
+                  <strong className="text-foreground">{stats.pages}</strong> pages
+                </span>
+                <span>
+                  <strong className="text-foreground">{stats.words.toLocaleString()}</strong> words
+                </span>
+                <span>
+                  <strong className="text-foreground">{stats.headings}</strong> headings
+                </span>
+                <span>
+                  <strong className="text-foreground">{stats.lists}</strong> list items
+                </span>
+              </div>
+            )}
+
+            <Button variant="ghost" size="sm" onClick={clearFile}>
+              Clear
+            </Button>
+          </div>
+
+          {/* Tabs: Preview / Raw */}
+          <Tabs defaultValue="preview" className="w-full">
+            <div className="flex items-center justify-between mb-4">
+              <TabsList>
+                <TabsTrigger value="preview">Preview</TabsTrigger>
+                <TabsTrigger value="raw">Raw Markdown</TabsTrigger>
+              </TabsList>
+
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={copyToClipboard}
+                  disabled={!markdown}
+                >
+                  {copied ? (
+                    <>
+                      <Check className="size-4 mr-2" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="size-4 mr-2" />
+                      Copy
+                    </>
+                  )}
+                </Button>
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={downloadMarkdown}
+                  disabled={!markdown}
+                >
+                  <Download className="size-4 mr-2" />
+                  Download .md
+                </Button>
+              </div>
+            </div>
+
+            <TabsContent value="preview" className="mt-0">
+              <div className="border rounded-lg p-6 bg-card max-h-[600px] overflow-auto">
+                <article className="prose prose-sm dark:prose-invert max-w-none">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {markdown}
+                  </ReactMarkdown>
+                </article>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="raw" className="mt-0">
+              <textarea
+                value={markdown}
+                readOnly
+                className={cn(
+                  "w-full h-[600px] p-4 font-mono text-sm",
+                  "border rounded-lg bg-card resize-none",
+                  "focus:outline-none focus:ring-2 focus:ring-ring"
+                )}
+              />
+            </TabsContent>
+          </Tabs>
+        </div>
+      )}
+
+      {/* Empty state after clearing or error */}
+      {file && !isConverting && !markdown && error && (
+        <div className="flex flex-col items-center justify-center py-12 gap-4">
+          <p className="text-destructive">{error}</p>
+          <Button variant="outline" onClick={clearFile}>
+            Try another file
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/pdf-to-markdown.ts
+++ b/lib/pdf-to-markdown.ts
@@ -1,0 +1,352 @@
+export interface ConversionOptions {
+  headingSensitivity: "low" | "medium" | "high";
+  detectLists: boolean;
+  addPageBreaks: boolean;
+}
+
+export interface ConversionStats {
+  pages: number;
+  words: number;
+  headings: number;
+  lists: number;
+}
+
+export interface ConversionResult {
+  markdown: string;
+  stats: ConversionStats;
+}
+
+interface TextItem {
+  str: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  fontSize: number;
+  fontName: string;
+}
+
+interface TextLine {
+  items: TextItem[];
+  y: number;
+  minX: number;
+}
+
+const DEFAULT_OPTIONS: ConversionOptions = {
+  headingSensitivity: "medium",
+  detectLists: true,
+  addPageBreaks: true,
+};
+
+// Font size thresholds for heading detection (relative to base font size)
+const HEADING_THRESHOLDS = {
+  low: { h1: 1.8, h2: 1.5, h3: 1.3 },
+  medium: { h1: 1.5, h2: 1.3, h3: 1.2 },
+  high: { h1: 1.3, h2: 1.2, h3: 1.1 },
+};
+
+// Bullet patterns for list detection
+const BULLET_PATTERNS = /^[\u2022\u2023\u25E6\u2043\u2219•\-\*\>]\s*/;
+const NUMBERED_PATTERN = /^(\d+[\.\)]\s*|[a-zA-Z][\.\)]\s*)/;
+
+function isBold(fontName: string): boolean {
+  const lower = fontName.toLowerCase();
+  return lower.includes("bold") || lower.includes("heavy") || lower.includes("black");
+}
+
+function isItalic(fontName: string): boolean {
+  const lower = fontName.toLowerCase();
+  return lower.includes("italic") || lower.includes("oblique");
+}
+
+function groupItemsIntoLines(items: TextItem[], lineThreshold = 3): TextLine[] {
+  if (items.length === 0) return [];
+
+  // Sort by y position (top to bottom), then by x position (left to right)
+  const sorted = [...items].sort((a, b) => {
+    if (Math.abs(a.y - b.y) > lineThreshold) {
+      return b.y - a.y; // Higher y = higher on page in PDF coordinates
+    }
+    return a.x - b.x;
+  });
+
+  const lines: TextLine[] = [];
+  let currentLine: TextItem[] = [sorted[0]];
+  let currentY = sorted[0].y;
+
+  for (let i = 1; i < sorted.length; i++) {
+    const item = sorted[i];
+    if (Math.abs(item.y - currentY) <= lineThreshold) {
+      currentLine.push(item);
+    } else {
+      // Sort current line by x position
+      currentLine.sort((a, b) => a.x - b.x);
+      lines.push({
+        items: currentLine,
+        y: currentY,
+        minX: Math.min(...currentLine.map((i) => i.x)),
+      });
+      currentLine = [item];
+      currentY = item.y;
+    }
+  }
+
+  // Don't forget the last line
+  if (currentLine.length > 0) {
+    currentLine.sort((a, b) => a.x - b.x);
+    lines.push({
+      items: currentLine,
+      y: currentY,
+      minX: Math.min(...currentLine.map((i) => i.x)),
+    });
+  }
+
+  return lines;
+}
+
+function calculateBaseFontSize(items: TextItem[]): number {
+  if (items.length === 0) return 12;
+
+  // Find the most common font size (likely body text)
+  const fontSizeCounts = new Map<number, number>();
+  for (const item of items) {
+    const rounded = Math.round(item.fontSize);
+    fontSizeCounts.set(rounded, (fontSizeCounts.get(rounded) || 0) + item.str.length);
+  }
+
+  let maxCount = 0;
+  let baseFontSize = 12;
+  for (const [size, count] of fontSizeCounts) {
+    if (count > maxCount) {
+      maxCount = count;
+      baseFontSize = size;
+    }
+  }
+
+  return baseFontSize;
+}
+
+function lineToMarkdown(
+  line: TextLine,
+  baseFontSize: number,
+  options: ConversionOptions,
+  baseIndent: number
+): { text: string; isHeading: boolean; isList: boolean } {
+  const thresholds = HEADING_THRESHOLDS[options.headingSensitivity];
+  const lineText = line.items.map((item) => item.str).join("");
+  const trimmedText = lineText.trim();
+
+  if (!trimmedText) {
+    return { text: "", isHeading: false, isList: false };
+  }
+
+  // Calculate average font size for the line
+  const totalChars = line.items.reduce((sum, item) => sum + item.str.length, 0);
+  const weightedFontSize =
+    line.items.reduce((sum, item) => sum + item.fontSize * item.str.length, 0) / totalChars;
+  const fontRatio = weightedFontSize / baseFontSize;
+
+  // Check if line is a heading based on font size
+  let headingLevel = 0;
+  if (fontRatio >= thresholds.h1) {
+    headingLevel = 1;
+  } else if (fontRatio >= thresholds.h2) {
+    headingLevel = 2;
+  } else if (fontRatio >= thresholds.h3) {
+    headingLevel = 3;
+  }
+
+  if (headingLevel > 0) {
+    const prefix = "#".repeat(headingLevel);
+    return { text: `${prefix} ${trimmedText}`, isHeading: true, isList: false };
+  }
+
+  // Check for lists
+  if (options.detectLists) {
+    const bulletMatch = trimmedText.match(BULLET_PATTERNS);
+    if (bulletMatch) {
+      const content = trimmedText.slice(bulletMatch[0].length);
+      const formattedContent = applyInlineFormatting(content, line.items.slice(bulletMatch[0].length));
+      return { text: `- ${formattedContent}`, isHeading: false, isList: true };
+    }
+
+    const numberedMatch = trimmedText.match(NUMBERED_PATTERN);
+    if (numberedMatch) {
+      const content = trimmedText.slice(numberedMatch[0].length);
+      const formattedContent = applyInlineFormatting(content, line.items);
+      // Extract number for ordered list
+      const num = numberedMatch[1].replace(/[\.\)]\s*$/, "");
+      const numericNum = /^\d+$/.test(num) ? num : "1";
+      return { text: `${numericNum}. ${formattedContent}`, isHeading: false, isList: true };
+    }
+
+    // Check for indentation-based lists (items significantly indented from baseline)
+    const indentDiff = line.minX - baseIndent;
+    if (indentDiff > 20) {
+      const formattedContent = applyInlineFormatting(trimmedText, line.items);
+      return { text: `  - ${formattedContent}`, isHeading: false, isList: true };
+    }
+  }
+
+  // Regular paragraph with inline formatting
+  const formattedText = applyInlineFormatting(trimmedText, line.items);
+  return { text: formattedText, isHeading: false, isList: false };
+}
+
+function applyInlineFormatting(text: string, items: TextItem[]): string {
+  if (items.length === 0) return text;
+
+  // Build formatted text by checking font properties
+  let result = "";
+  let currentBold = false;
+  let currentItalic = false;
+
+  for (const item of items) {
+    const itemBold = isBold(item.fontName);
+    const itemItalic = isItalic(item.fontName);
+
+    // Close tags if formatting changes
+    if (currentItalic && !itemItalic) {
+      result += "*";
+      currentItalic = false;
+    }
+    if (currentBold && !itemBold) {
+      result += "**";
+      currentBold = false;
+    }
+
+    // Open tags if formatting changes
+    if (!currentBold && itemBold) {
+      result += "**";
+      currentBold = true;
+    }
+    if (!currentItalic && itemItalic) {
+      result += "*";
+      currentItalic = true;
+    }
+
+    result += item.str;
+  }
+
+  // Close any remaining tags
+  if (currentItalic) result += "*";
+  if (currentBold) result += "**";
+
+  return result;
+}
+
+// Dynamic import to avoid SSR issues
+async function getPdfJs() {
+  const pdfjs = await import("pdfjs-dist");
+  pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
+  return pdfjs;
+}
+
+export async function convertPdfToMarkdown(
+  data: ArrayBuffer,
+  options: Partial<ConversionOptions> = {},
+  onProgress?: (current: number, total: number) => void
+): Promise<ConversionResult> {
+  const opts: ConversionOptions = { ...DEFAULT_OPTIONS, ...options };
+  const pdfjs = await getPdfJs();
+
+  const pdf = await pdfjs.getDocument({ data }).promise;
+  const numPages = pdf.numPages;
+
+  const markdownParts: string[] = [];
+  let totalWords = 0;
+  let totalHeadings = 0;
+  let totalLists = 0;
+
+  for (let pageNum = 1; pageNum <= numPages; pageNum++) {
+    if (onProgress) {
+      onProgress(pageNum, numPages);
+    }
+
+    const page = await pdf.getPage(pageNum);
+    const textContent = await page.getTextContent();
+    const items: TextItem[] = [];
+
+    for (const item of textContent.items) {
+      if ("str" in item && item.str.trim()) {
+        const transform = item.transform;
+        items.push({
+          str: item.str,
+          x: transform[4],
+          y: transform[5],
+          width: item.width,
+          height: item.height,
+          fontSize: Math.abs(transform[0]) || Math.abs(transform[3]) || 12,
+          fontName: item.fontName || "",
+        });
+      }
+    }
+
+    if (items.length === 0) continue;
+
+    const baseFontSize = calculateBaseFontSize(items);
+    const lines = groupItemsIntoLines(items);
+
+    // Calculate base indent (leftmost position that appears frequently)
+    const xPositions = lines.map((l) => Math.round(l.minX));
+    const xCounts = new Map<number, number>();
+    for (const x of xPositions) {
+      xCounts.set(x, (xCounts.get(x) || 0) + 1);
+    }
+    let baseIndent = Math.min(...xPositions);
+    let maxCount = 0;
+    for (const [x, count] of xCounts) {
+      if (count > maxCount) {
+        maxCount = count;
+        baseIndent = x;
+      }
+    }
+
+    const pageMarkdown: string[] = [];
+    let previousY = lines[0]?.y || 0;
+    let inList = false;
+
+    for (const line of lines) {
+      const { text, isHeading, isList } = lineToMarkdown(line, baseFontSize, opts, baseIndent);
+
+      if (!text) continue;
+
+      // Add paragraph breaks for large vertical gaps
+      const yGap = previousY - line.y;
+      if (yGap > baseFontSize * 1.5 && pageMarkdown.length > 0 && !isHeading) {
+        // Add blank line for paragraph break
+        if (!inList || !isList) {
+          pageMarkdown.push("");
+        }
+      }
+
+      pageMarkdown.push(text);
+      previousY = line.y;
+
+      // Track stats
+      totalWords += text.split(/\s+/).filter((w) => w.length > 0).length;
+      if (isHeading) totalHeadings++;
+      if (isList) totalLists++;
+      inList = isList;
+    }
+
+    if (pageMarkdown.length > 0) {
+      markdownParts.push(pageMarkdown.join("\n"));
+    }
+
+    // Add page break marker
+    if (opts.addPageBreaks && pageNum < numPages) {
+      markdownParts.push("\n---\n");
+    }
+  }
+
+  return {
+    markdown: markdownParts.join("\n\n"),
+    stats: {
+      pages: numPages,
+      words: totalWords,
+      headings: totalHeadings,
+      lists: totalLists,
+    },
+  };
+}

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -261,6 +261,14 @@ export const toolCategories: ToolCategory[] = [
         icon: FileType,
         href: "/tools/font-explorer",
       },
+      {
+        id: "pdf-to-markdown",
+        name: "PDF to Markdown",
+        description: "Convert PDF documents to Markdown",
+        icon: FileText,
+        href: "/tools/pdf-to-markdown",
+        new: true,
+      },
     ],
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "nerdamer": "^1.1.13",
         "next": "16.1.0",
         "pdf-lib": "^1.17.1",
+        "pdfjs-dist": "^5.4.624",
         "qr-code-styling": "^1.9.2",
         "qrcode": "^1.5.4",
         "react": "19.2.3",
@@ -110,6 +111,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -345,6 +347,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1215,6 +1218,256 @@
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.89.tgz",
+      "integrity": "sha512-7GjmkMirJHejeALCqUnZY3QwID7bbumOiLrqq2LKgxrdjdmxWQBTc6rcASa2u8wuWrH7qo4/4n/VNrOwCoKlKg==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.89",
+        "@napi-rs/canvas-darwin-arm64": "0.1.89",
+        "@napi-rs/canvas-darwin-x64": "0.1.89",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.89",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.89",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.89",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.89",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.89",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.89",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.89",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.89"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.89.tgz",
+      "integrity": "sha512-CXxQTXsjtQqKGENS8Ejv9pZOFJhOPIl2goenS+aU8dY4DygvkyagDhy/I07D1YLqrDtPvLEX5zZHt8qUdnuIpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.89.tgz",
+      "integrity": "sha512-k29cR/Zl20WLYM7M8YePevRu2VQRaKcRedYr1V/8FFHkyIQ8kShEV+MPoPGi+znvmd17Eqjy2Pk2F2kpM2umVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.89.tgz",
+      "integrity": "sha512-iUragqhBrA5FqU13pkhYBDbUD1WEAIlT8R2+fj6xHICY2nemzwMUI8OENDhRh7zuL06YDcRwENbjAVxOmaX9jg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.89.tgz",
+      "integrity": "sha512-y3SM9sfDWasY58ftoaI09YBFm35Ig8tosZqgahLJ2WGqawCusGNPV9P0/4PsrLOCZqGg629WxexQMY25n7zcvA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.89.tgz",
+      "integrity": "sha512-NEoF9y8xq5fX8HG8aZunBom1ILdTwt7ayBzSBIwrmitk7snj4W6Fz/yN/ZOmlM1iyzHDNX5Xn0n+VgWCF8BEdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.89.tgz",
+      "integrity": "sha512-UQQkIEzV12/l60j1ziMjZ+mtodICNUbrd205uAhbyTw0t60CrC/EsKb5/aJWGq1wM0agvcgZV72JJCKfLS6+4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.89.tgz",
+      "integrity": "sha512-1/VmEoFaIO6ONeeEMGoWF17wOYZOl5hxDC1ios2Bkz/oQjbJJ8DY/X22vWTmvuUKWWhBVlo63pxLGZbjJU/heA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.89.tgz",
+      "integrity": "sha512-ebLuqkCuaPIkKgKH9q4+pqWi1tkPOfiTk5PM1LKR1tB9iO9sFNVSIgwEp+SJreTSbA2DK5rW8lQXiN78SjtcvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.89.tgz",
+      "integrity": "sha512-w+5qxHzplvA4BkHhCaizNMLLXiI+CfP84YhpHm/PqMub4u8J0uOAv+aaGv40rYEYra5hHRWr9LUd6cfW32o9/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.89.tgz",
+      "integrity": "sha512-DmyXa5lJHcjOsDC78BM3bnEECqbK3xASVMrKfvtT/7S7Z8NGQOugvu+L7b41V6cexCd34mBWgMOsjoEBceeB1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.89",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.89.tgz",
+      "integrity": "sha512-WMej0LZrIqIncQcx0JHaMXlnAG7sncwJh7obs/GBgp0xF9qABjwoRwIooMWCZkSansapKGNUHhamY6qEnFN7gA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -3038,6 +3291,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3048,6 +3302,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3103,6 +3358,7 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -3658,6 +3914,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4041,6 +4298,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4599,6 +4857,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5223,6 +5482,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5408,6 +5668,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8566,6 +8827,13 @@
         "double-bits": "^1.1.0"
       }
     },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -8915,6 +9183,19 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.624",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.624.tgz",
+      "integrity": "sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.88",
+        "node-readable-to-web-readable-stream": "^0.4.2"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9134,6 +9415,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9143,6 +9425,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10161,7 +10444,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -10255,6 +10539,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10468,6 +10753,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11028,6 +11314,7 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "nerdamer": "^1.1.13",
     "next": "16.1.0",
     "pdf-lib": "^1.17.1",
+    "pdfjs-dist": "^5.4.624",
     "qr-code-styling": "^1.9.2",
     "qrcode": "^1.5.4",
     "react": "19.2.3",


### PR DESCRIPTION
- Add pdfjs-dist dependency for PDF text extraction
- Create /lib/pdf-to-markdown.ts with core extraction logic:
  - Heading detection based on font size ratios (configurable sensitivity)
  - List detection (bullets, numbered items, indentation-based)
  - Bold/italic detection from font names
  - Paragraph grouping by vertical gaps
- Create /components/tools/pdf-to-markdown.tsx UI with:
  - Drag-and-drop file upload
  - Options panel (heading sensitivity, list detection, page breaks)
  - Preview (react-markdown) and Raw Markdown tabs
  - Download .md and copy to clipboard actions
  - Stats display (pages, words, headings, list items)
- Register tool in Typography & Text category

<img width="233" height="322" alt="image" src="https://github.com/user-attachments/assets/e0e4514d-2c55-4180-bc81-75dc19f01317" />
<img width="1187" height="540" alt="image" src="https://github.com/user-attachments/assets/f443b14a-b42a-483c-bba3-ef7609815588" />
<img width="943" height="987" alt="image" src="https://github.com/user-attachments/assets/1dc42aa9-eb5b-4db0-835a-9ab11b75e473" />
