### PR TITLE
Accessibility: Add SkipLink and refactor navigation for better UX

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
 import { AppHeader } from "@/components/app-header";
 import { ColourNotationProvider } from "@/components/colour-notation-provider";
+import SkipLink from "@/components/ui/skip-link";
 
 export const metadata: Metadata = {
   title: "delphitools",
@@ -34,10 +35,17 @@ export default function RootLayout({
       <body className="font-mono antialiased">
         <ColourNotationProvider>
           <SidebarProvider>
+            <SkipLink />
             <AppSidebar />
             <SidebarInset>
               <AppHeader />
-              <main className="flex-1 overflow-auto">{children}</main>
+              <main
+                className="flex-1 overflow-auto"
+                id="main-content"
+                tabIndex={-1}
+              >
+                {children}
+              </main>
             </SidebarInset>
           </SidebarProvider>
         </ColourNotationProvider>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -96,92 +96,96 @@ export function AppSidebar() {
         </div>
       </div>
 
-      <SidebarContent>
-        {!query && (
-        <SidebarGroup>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton
-                asChild
-                isActive={pathname === "/"}
-                tooltip="Home"
-              >
-                <Link href="/">
-                  <Home className="size-4" />
-                  <span>Home</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarGroup>
-        )}
-
-        {query && filteredFeatured.length === 0 && filteredCategories.length === 0 && (
-          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-            No tools found
-          </div>
-        )}
-
-        {filteredFeatured.length > 0 && (
-        <SidebarGroup>
-          <SidebarGroupLabel className="flex items-center gap-1.5">
-            <Star className="size-3 text-amber-500 fill-amber-500" />
-            Greatest Hits
-          </SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {filteredFeatured.map((tool) => {
-                const Icon = tool.icon;
-                const isActive = pathname === tool.href;
-                return (
-                  <SidebarMenuItem key={tool.id}>
-                    <SidebarMenuButton
-                      asChild
-                      isActive={isActive}
-                      tooltip={tool.name}
-                      className="text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300"
-                    >
-                      <Link href={tool.href} prefetch={false}>
-                        <Icon className="size-4" />
-                        <span>{tool.name}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                );
-              })}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        )}
-
-        {filteredCategories.map((category) => (
-          <SidebarGroup key={category.id}>
-            <SidebarGroupLabel>{category.name}</SidebarGroupLabel>
-            <SidebarGroupContent>
+      <nav>
+        <SidebarContent>
+          {!query && (
+            <SidebarGroup>
               <SidebarMenu>
-                {category.tools.map((tool) => {
-                  const Icon = tool.icon;
-                  const isActive = pathname === tool.href;
-                  return (
-                    <SidebarMenuItem key={tool.id}>
-                      <SidebarMenuButton
-                        asChild
-                        isActive={isActive}
-                        tooltip={tool.name}
-                      >
-                        <Link href={tool.href} prefetch={false}>
-                          <Icon className="size-4" />
-                          <span>{tool.name}</span>
-                        </Link>
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                  );
-                })}
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={pathname === "/"}
+                    tooltip="Home"
+                  >
+                    <Link href="/">
+                      <Home className="size-4" />
+                      <span>Home</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
               </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        ))}
-      </SidebarContent>
+            </SidebarGroup>
+          )}
+
+          {query &&
+            filteredFeatured.length === 0 &&
+            filteredCategories.length === 0 && (
+              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                No tools found
+              </div>
+            )}
+
+          {filteredFeatured.length > 0 && (
+            <SidebarGroup>
+              <SidebarGroupLabel className="flex items-center gap-1.5">
+                <Star className="size-3 text-amber-500 fill-amber-500" />
+                Greatest Hits
+              </SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  {filteredFeatured.map((tool) => {
+                    const Icon = tool.icon;
+                    const isActive = pathname === tool.href;
+                    return (
+                      <SidebarMenuItem key={tool.id}>
+                        <SidebarMenuButton
+                          asChild
+                          isActive={isActive}
+                          tooltip={tool.name}
+                          className="text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300"
+                        >
+                          <Link href={tool.href} prefetch={false}>
+                            <Icon className="size-4" />
+                            <span>{tool.name}</span>
+                          </Link>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    );
+                  })}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          )}
+
+          {filteredCategories.map((category) => (
+            <SidebarGroup key={category.id}>
+              <SidebarGroupLabel>{category.name}</SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  {category.tools.map((tool) => {
+                    const Icon = tool.icon;
+                    const isActive = pathname === tool.href;
+                    return (
+                      <SidebarMenuItem key={tool.id}>
+                        <SidebarMenuButton
+                          asChild
+                          isActive={isActive}
+                          tooltip={tool.name}
+                        >
+                          <Link href={tool.href} prefetch={false}>
+                            <Icon className="size-4" />
+                            <span>{tool.name}</span>
+                          </Link>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    );
+                  })}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          ))}
+        </SidebarContent>
+      </nav>
 
       <SidebarFooter className="border-t border-sidebar-border">
         <Dialog>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -96,7 +96,7 @@ export function AppSidebar() {
         </div>
       </div>
 
-      <nav>
+      <nav aria-label="Main Navigation">
         <SidebarContent>
           {!query && (
             <SidebarGroup>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -370,7 +370,7 @@ function SidebarSeparator({
 
 function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <nav
+    <div
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -370,7 +370,7 @@ function SidebarSeparator({
 
 function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div
+    <nav
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(

--- a/components/ui/skip-link.tsx
+++ b/components/ui/skip-link.tsx
@@ -2,7 +2,7 @@ const SkipLink = () => {
   return (
     <a
       href="#main-content"
-      className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-1000 focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:border focus:rounded-md"
+      className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-4 focus:z-[1000] focus:px-4 focus:py-2 focus:rounded-[var(--radius)]focus:bg-background focus:text-foreground focus:border focus:border-border focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:font-medium"
     >
       Skip to main content
     </a>

--- a/components/ui/skip-link.tsx
+++ b/components/ui/skip-link.tsx
@@ -2,7 +2,7 @@ const SkipLink = () => {
   return (
     <a
       href="#main-content"
-      className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-4 focus:z-[1000] focus:px-4 focus:py-2 focus:rounded-[var(--radius)]focus:bg-background focus:text-foreground focus:border focus:border-border focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:font-medium"
+      className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-4 focus:z-[1000] focus:px-4 focus:py-2 focus:rounded-[var(--radius)] focus:bg-background focus:text-foreground focus:border focus:border-border focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:font-medium"
     >
       Skip to main content
     </a>

--- a/components/ui/skip-link.tsx
+++ b/components/ui/skip-link.tsx
@@ -1,0 +1,12 @@
+const SkipLink = () => {
+  return (
+    <a
+      href="#main-content"
+      className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:border focus:rounded-md"
+    >
+      Skip to main content
+    </a>
+  );
+};
+
+export default SkipLink;

--- a/components/ui/skip-link.tsx
+++ b/components/ui/skip-link.tsx
@@ -2,7 +2,7 @@ const SkipLink = () => {
   return (
     <a
       href="#main-content"
-      className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:border focus:rounded-md"
+      className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-1000 focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:border focus:rounded-md"
     >
       Skip to main content
     </a>


### PR DESCRIPTION
This PR fixes issue #24

This contribution focuses on improving the keyboard navigation and accessibility (A11y) of the application. With the current density of the sidebar, users relying on assistive technologies or keyboard-only navigation had to cycle through numerous links before reaching the primary tool content.

**Changes Made**
***Added***
- SkipLink Component: Implemented a `Skip to main content` link as the first focusable element.
- Styled with pure Tailwind CSS using `sr-only` and `focus:not-sr-only`.
- Used a high `z-index (1000)` to ensure the link appears above all elements

***Refactored Sidebar Structure***
- Updated the sidebar container from a generic `<div>` to a semantic `<nav>` element.
- Ensured the navigation remains lightweight without redundant ARIA roles, following W3C best practices.