### PR TITLE
feat(tools): add media URL clipboard tool and shared crop

### DIFF
--- a/app/tools/[toolId]/page.tsx
+++ b/app/tools/[toolId]/page.tsx
@@ -52,6 +52,7 @@ const toolComponents: Record<string, React.ComponentType> = {
   "shavian-transliterator": dynamic(() => import("@/components/tools/shavian-transliterator").then(mod => mod.ShavianTransliteratorTool)),
   "imposer": dynamic(() => import("@/components/tools/imposer").then(mod => mod.ImposerTool)),
   "paste-image": dynamic(() => import("@/components/tools/paste-image").then(mod => mod.PasteImageTool)),
+  "media-url-to-clipboard": dynamic(() => import("@/components/tools/media-url-to-clipboard").then(mod => mod.MediaUrlToClipboardTool)),
   "image-clipper": dynamic(() => import("@/components/tools/image-clipper").then(mod => mod.ImageClipperTool)),
   "pixel-picker": dynamic(() => import("@/components/tools/pixel-picker").then(mod => mod.PixelPickerTool)),
   "palette-extractor": dynamic(() => import("@/components/tools/palette-extractor").then(mod => mod.PaletteExtractorTool)),

--- a/components/tools/media-url-to-clipboard.tsx
+++ b/components/tools/media-url-to-clipboard.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  type FormEvent,
+} from "react";
+import {
+  ClipboardCopy,
+  Link2,
+  Loader2,
+  Scissors,
+  Check,
+  X,
+  RotateCcw,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  usePasteStyleImageCrop,
+  PasteStyleCropOverlay,
+} from "@/components/tools/paste-style-image-crop";
+
+function resolveMediaUrl(raw: string): URL | null {
+  const t = raw.trim();
+  if (!t) return null;
+  try {
+    return new URL(t);
+  } catch {
+    try {
+      if (t.startsWith("//")) return new URL(`https:${t}`);
+      if (t.startsWith("/")) return new URL(t, window.location.origin);
+      return new URL(`https://${t}`);
+    } catch {
+      return null;
+    }
+  }
+}
+
+async function blobToPng(blob: Blob): Promise<Blob> {
+  const bmp = await createImageBitmap(blob);
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = bmp.width;
+    canvas.height = bmp.height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("no ctx");
+    ctx.drawImage(bmp, 0, 0);
+    const out = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, "image/png"),
+    );
+    if (!out) throw new Error("toBlob failed");
+    return out;
+  } finally {
+    bmp.close();
+  }
+}
+
+async function tryDecodeAsImage(blob: Blob): Promise<void> {
+  try {
+    await createImageBitmap(blob);
+  } catch {
+    throw new Error("IMAGE_DECODE");
+  }
+}
+
+export function MediaUrlToClipboardTool() {
+  const [urlInput, setUrlInput] = useState("");
+  const [image, setImage] = useState<string | null>(null);
+  const [originalImage, setOriginalImage] = useState<string | null>(null);
+
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const [copyState, setCopyState] = useState<"idle" | "ok" | "err">("idle");
+  const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const latestBlobRef = useRef<Blob | null>(null);
+  const originalBlobRef = useRef<Blob | null>(null);
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const imageRef = useRef<HTMLImageElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const objectUrls = useRef<Set<string>>(new Set());
+
+  const createSafeObjectURL = useCallback((blob: Blob | MediaSource) => {
+    const url = URL.createObjectURL(blob);
+    objectUrls.current.add(url);
+    return url;
+  }, []);
+
+  const revokeSafeObjectURL = useCallback((url: string | null) => {
+    if (url && objectUrls.current.has(url)) {
+      URL.revokeObjectURL(url);
+      objectUrls.current.delete(url);
+    }
+  }, []);
+
+  const handleCroppedBlob = useCallback(
+    (blob: Blob) => {
+      latestBlobRef.current = blob;
+      const url = createSafeObjectURL(blob);
+      setImage((prev) => {
+        if (prev && prev !== originalImage) revokeSafeObjectURL(prev);
+        return url;
+      });
+    },
+    [createSafeObjectURL, revokeSafeObjectURL, originalImage],
+  );
+
+  const {
+    isCropping,
+    cropArea,
+    imageScale,
+    startCropping,
+    cancelCropping,
+    applyCrop,
+    handleDragStart,
+  } = usePasteStyleImageCrop({
+    imageRef,
+    canvasRef,
+    onCroppedBlob: handleCroppedBlob,
+  });
+
+  useEffect(() => {
+    const objurlcurr = objectUrls.current;
+    return () => {
+      if (copyResetRef.current) clearTimeout(copyResetRef.current);
+      objurlcurr.forEach((url) => URL.revokeObjectURL(url));
+      objurlcurr.clear();
+    };
+  }, []);
+
+  const clearLoaded = () => {
+    cancelCropping();
+    if (copyResetRef.current) clearTimeout(copyResetRef.current);
+    setCopyState("idle");
+    setLoadError(null);
+    latestBlobRef.current = null;
+    originalBlobRef.current = null;
+    if (image) revokeSafeObjectURL(image);
+    if (originalImage && originalImage !== image)
+      revokeSafeObjectURL(originalImage);
+    setImage(null);
+    setOriginalImage(null);
+  };
+
+  const loadFromUrl = useCallback(async () => {
+    setLoadError(null);
+    setCopyState("idle");
+
+    const parsed = resolveMediaUrl(urlInput);
+    if (!parsed) {
+      setLoadError("That address is not a valid URL.");
+      return;
+    }
+
+    if (!(parsed.protocol === "http:" || parsed.protocol === "https:")) {
+      setLoadError("Only http and https links are supported.");
+      return;
+    }
+
+    setLoading(true);
+    cancelCropping();
+    try {
+      const res = await fetch(parsed.href, {
+        mode: "cors",
+        credentials: "omit",
+        cache: "no-store",
+      });
+
+      if (!res.ok) {
+        setLoadError(
+          `Could not load the image (server responded with ${res.status} ${res.statusText}).`,
+        );
+        return;
+      }
+
+      const blob = await res.blob();
+
+      if (!blob.size) {
+        setLoadError("The response was empty.");
+        return;
+      }
+
+      const type = blob.type.toLowerCase();
+      const looksLikeImage =
+        type.startsWith("image/") ||
+        type === "application/octet-stream" ||
+        type === "";
+
+      if (!looksLikeImage) {
+        setLoadError(
+          "The URL did not return an image type this tool can use (check the content type).",
+        );
+        return;
+      }
+
+      await tryDecodeAsImage(blob);
+
+      originalBlobRef.current = blob;
+
+      const displayUrl = createSafeObjectURL(blob);
+      latestBlobRef.current = blob;
+
+      setImage((prev) => {
+        if (prev) revokeSafeObjectURL(prev);
+        return displayUrl;
+      });
+      setOriginalImage((prev) => {
+        if (prev) revokeSafeObjectURL(prev);
+        return displayUrl;
+      });
+
+      cancelCropping();
+    } catch (err) {
+      const msg =
+        err instanceof Error && err.message === "IMAGE_DECODE"
+          ? "The downloaded file cannot be decoded as an image."
+          : "Could not load the image (network error, blocked by CORS, or invalid URL).";
+      setLoadError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [urlInput, createSafeObjectURL, revokeSafeObjectURL, cancelCropping]);
+
+  const resetImage = () => {
+    if (image && image !== originalImage) revokeSafeObjectURL(image);
+    setImage(originalImage);
+    cancelCropping();
+    const ob = originalBlobRef.current;
+    latestBlobRef.current = ob ?? null;
+  };
+
+  const copyImage = async () => {
+    setCopyState("idle");
+    if (copyResetRef.current) clearTimeout(copyResetRef.current);
+
+    const b = latestBlobRef.current;
+    if (!b) {
+      setCopyState("err");
+      return;
+    }
+
+    if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) {
+      setCopyState("err");
+      return;
+    }
+
+    try {
+      const png = await blobToPng(b);
+      await navigator.clipboard.write([
+        new ClipboardItem({ "image/png": png }),
+      ]);
+      setCopyState("ok");
+      copyResetRef.current = setTimeout(() => {
+        setCopyState("idle");
+        copyResetRef.current = null;
+      }, 2200);
+    } catch {
+      setCopyState("err");
+    }
+  };
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    setLoadError(null);
+    setCopyState("idle");
+    void loadFromUrl();
+  };
+
+  return (
+    <div className="space-y-4">
+      <canvas ref={canvasRef} className="hidden" />
+
+      <form onSubmit={onSubmit} className="space-y-3">
+        <div className="flex flex-col sm:flex-row gap-2 items-stretch sm:items-end">
+          <div className="flex-1 space-y-1.5">
+            <label
+              htmlFor="media-url"
+              className="text-sm font-medium text-foreground"
+            >
+              Image URL
+            </label>
+            <div className="relative">
+              <Link2 className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+              <Input
+                id="media-url"
+                type="url"
+                placeholder="https://example.com/image.png"
+                value={urlInput}
+                onChange={(e) => setUrlInput(e.target.value)}
+                className="pl-9 font-mono text-sm"
+                autoComplete="url"
+              />
+            </div>
+          </div>
+          <Button type="submit" disabled={loading} className="shrink-0">
+            {loading ? (
+              <>
+                <Loader2 className="size-4 mr-2 animate-spin" />
+                Loading
+              </>
+            ) : (
+              <>Load image</>
+            )}
+          </Button>
+        </div>
+      </form>
+
+      {loadError && (
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          {loadError}
+        </div>
+      )}
+
+      {image ? (
+        <div className="space-y-4">
+          <div className="flex items-center gap-2 flex-wrap">
+            {!isCropping ? (
+              <Button onClick={startCropping} variant="secondary" size="sm">
+                <Scissors className="size-4 mr-2" /> Crop
+              </Button>
+            ) : (
+              <>
+                <Button onClick={applyCrop} size="sm">
+                  <Check className="size-4 mr-2" /> Apply Crop
+                </Button>
+                <Button onClick={cancelCropping} variant="outline" size="sm">
+                  Cancel
+                </Button>
+              </>
+            )}
+
+            {!isCropping && (
+              <>
+                <Button onClick={copyImage} size="sm">
+                  <ClipboardCopy className="size-4 mr-2" />
+                  Copy to clipboard
+                </Button>
+                {image !== originalImage && (
+                  <Button onClick={resetImage} variant="outline" size="sm">
+                    <RotateCcw className="size-4 mr-2" /> Reset
+                  </Button>
+                )}
+                <div className="flex-1" />
+                <Button onClick={clearLoaded} variant="ghost" size="sm">
+                  <X className="size-4 mr-2" /> Clear
+                </Button>
+              </>
+            )}
+          </div>
+
+          {copyState === "ok" && (
+            <p className="text-sm text-muted-foreground" role="status">
+              Copied to clipboard as PNG.
+            </p>
+          )}
+          {copyState === "err" && (
+            <p className="text-sm text-destructive" role="alert">
+              Copy failed — try another browser, check permissions or image
+              size.
+            </p>
+          )}
+
+          <div className="flex justify-center bg-muted/30 rounded-xl border p-4 min-h-[50vh] overflow-hidden">
+            <div
+              ref={containerRef}
+              className="relative inline-block touch-none select-none"
+            >
+              <img
+                ref={imageRef}
+                src={image}
+                alt="Loaded from URL"
+                className="max-w-full max-h-[70vh] rounded shadow-sm pointer-events-none"
+                draggable={false}
+              />
+
+              <PasteStyleCropOverlay
+                isCropping={isCropping}
+                cropArea={cropArea}
+                imageScale={imageScale}
+                onDragStart={handleDragStart}
+              />
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/tools/paste-image.tsx
+++ b/components/tools/paste-image.tsx
@@ -11,33 +11,18 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useFilePaste } from "@/hooks/use-file-paste";
-
-interface CropArea {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
-type DragMode = "nw" | "ne" | "sw" | "se" | "n" | "s" | "e" | "w" | "move" | null;
+import {
+  usePasteStyleImageCrop,
+  PasteStyleCropOverlay,
+} from "@/components/tools/paste-style-image-crop";
 
 export function PasteImageTool() {
   const [image, setImage] = useState<string | null>(null);
   const [originalImage, setOriginalImage] = useState<string | null>(null);
-  const [isCropping, setIsCropping] = useState(false);
-  
-  const [cropArea, setCropArea] = useState<CropArea | null>(null);
-  const [dragMode, setDragMode] = useState<DragMode>(null);
-  const [dragStart, setDragStart] = useState<{ mouseX: number; mouseY: number; initialCrop: CropArea } | null>(null);
-  
-  const [imageScale, setImageScale] = useState({ x: 1, y: 1 });
-  
+
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-
-  const rafRef = useRef<number | null>(null);
-  const resizeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const objectUrls = useRef<Set<string>>(new Set());
 
@@ -54,224 +39,57 @@ export function PasteImageTool() {
     }
   }, []);
 
-  // Cleanup all Object URLs and timers on unmount
+  const handleCroppedBlob = useCallback(
+    (blob: Blob) => {
+      const url = createSafeObjectURL(blob);
+      setImage((prev) => {
+        if (prev && prev !== originalImage) revokeSafeObjectURL(prev);
+        return url;
+      });
+    },
+    [createSafeObjectURL, revokeSafeObjectURL, originalImage],
+  );
+
+  const {
+    isCropping,
+    cropArea,
+    imageScale,
+    startCropping,
+    cancelCropping,
+    applyCrop,
+    handleDragStart,
+  } = usePasteStyleImageCrop({
+    imageRef,
+    canvasRef,
+    onCroppedBlob: handleCroppedBlob,
+  });
+
   useEffect(() => {
     const objurlcurr = objectUrls.current;
     return () => {
-      objurlcurr.forEach(url => URL.revokeObjectURL(url));
+      objurlcurr.forEach((url) => URL.revokeObjectURL(url));
       objurlcurr.clear();
-      
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-      if (resizeTimeoutRef.current) clearTimeout(resizeTimeoutRef.current);
     };
   }, []);
 
   useFilePaste((file: File) => {
     const url = createSafeObjectURL(file);
 
-    setImage(prev => {
+    setImage((prev) => {
       if (prev) revokeSafeObjectURL(prev);
       return url;
     });
-    setOriginalImage(prev => {
+    setOriginalImage((prev) => {
       if (prev && prev !== url) revokeSafeObjectURL(prev);
       return url;
     });
 
-    setIsCropping(false);
-    setCropArea(null);
+    cancelCropping();
   }, "image/*");
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (resizeTimeoutRef.current) clearTimeout(resizeTimeoutRef.current);
-      resizeTimeoutRef.current = setTimeout(() => {
-        if (isCropping) {
-          setIsCropping(false);
-          setCropArea(null);
-        }
-      }, 150);
-    };
-    
-    window.addEventListener("resize", handleResize);
-    return () => {
-      if (resizeTimeoutRef.current) clearTimeout(resizeTimeoutRef.current);
-      window.removeEventListener("resize", handleResize);
-    };
-  }, [isCropping]);
-
-  const startCropping = () => {
-    if (imageRef.current) {
-      setCropArea({
-        x: 0,
-        y: 0,
-        width: imageRef.current.width,
-        height: imageRef.current.height,
-      });
-      setImageScale({
-        x: imageRef.current.naturalWidth / imageRef.current.width,
-        y: imageRef.current.naturalHeight / imageRef.current.height,
-      });
-      setIsCropping(true);
-    }
-  };
-
-  const handleDragStart = (e: React.MouseEvent | React.TouchEvent, mode: DragMode) => {
-    if (e.type !== "touchstart") {
-      e.preventDefault();
-    }
-    e.stopPropagation();
-    if (!cropArea) return;
-
-    const clientX = "touches" in e ? e.touches[0].clientX : (e as React.MouseEvent).clientX;
-    const clientY = "touches" in e ? e.touches[0].clientY : (e as React.MouseEvent).clientY;
-
-    setDragMode(mode);
-    setDragStart({
-      mouseX: clientX,
-      mouseY: clientY,
-      initialCrop: { ...cropArea },
-    });
-  };
-
-  const handleDragMove = useCallback((e: MouseEvent | TouchEvent) => {
-    if (!dragMode || !dragStart || !imageRef.current) return;
-    if (e.cancelable) e.preventDefault();
-
-    const clientX = "touches" in e ? e.touches[0].clientX : (e as MouseEvent).clientX;
-    const clientY = "touches" in e ? e.touches[0].clientY : (e as MouseEvent).clientY;
-
-    const dx = clientX - dragStart.mouseX;
-    const dy = clientY - dragStart.mouseY;
-
-    const { initialCrop } = dragStart;
-    let newX = initialCrop.x;
-    let newY = initialCrop.y;
-    let newW = initialCrop.width;
-    let newH = initialCrop.height;
-
-    const minSize = 20;
-    const maxW = imageRef.current.width;
-    const maxH = imageRef.current.height;
-
-    // Calculate new dimensions synchronously
-    if (dragMode === "move") {
-      newX = Math.max(0, Math.min(newX + dx, maxW - newW));
-      newY = Math.max(0, Math.min(newY + dy, maxH - newH));
-    } else {
-      if (dragMode.includes("n")) {
-        const proposedY = newY + dy;
-        const proposedH = newH - dy;
-        if (proposedH >= minSize && proposedY >= 0) {
-          newY = proposedY;
-          newH = proposedH;
-        } else if (proposedY < 0) {
-          newY = 0;
-          newH = initialCrop.y + initialCrop.height;
-        }
-      } else if (dragMode.includes("s")) {
-        const proposedH = newH + dy;
-        if (proposedH >= minSize && newY + proposedH <= maxH) {
-          newH = proposedH;
-        } else if (newY + proposedH > maxH) {
-          newH = maxH - newY;
-        }
-      }
-
-      if (dragMode.includes("w")) {
-        const proposedX = newX + dx;
-        const proposedW = newW - dx;
-        if (proposedW >= minSize && proposedX >= 0) {
-          newX = proposedX;
-          newW = proposedW;
-        } else if (proposedX < 0) {
-          newX = 0;
-          newW = initialCrop.x + initialCrop.width;
-        }
-      } else if (dragMode.includes("e")) {
-        const proposedW = newW + dx;
-        if (proposedW >= minSize && newX + proposedW <= maxW) {
-          newW = proposedW;
-        } else if (newX + proposedW > maxW) {
-          newW = maxW - newX;
-        }
-      }
-    }
-
-    if (rafRef.current !== null) return;
-    rafRef.current = requestAnimationFrame(() => {
-      setCropArea({ x: newX, y: newY, width: newW, height: newH });
-      rafRef.current = null;
-    });
-
-  }, [dragMode, dragStart]);
-
-  const handleDragEnd = useCallback(() => {
-    if (rafRef.current !== null) {
-      cancelAnimationFrame(rafRef.current);
-      rafRef.current = null;
-    }
-    setDragMode(null);
-    setDragStart(null);
-  }, []);
-
-  useEffect(() => {
-    if (dragMode) {
-      window.addEventListener("mousemove", handleDragMove);
-      window.addEventListener("mouseup", handleDragEnd);
-      window.addEventListener("touchmove", handleDragMove, { passive: false });
-      window.addEventListener("touchend", handleDragEnd);
-      return () => {
-        window.removeEventListener("mousemove", handleDragMove);
-        window.removeEventListener("mouseup", handleDragEnd);
-        window.removeEventListener("touchmove", handleDragMove);
-        window.removeEventListener("touchend", handleDragEnd);
-      };
-    }
-  }, [dragMode, handleDragMove, handleDragEnd]);
-
-  const applyCrop = () => {
-    if (!cropArea || !imageRef.current || !canvasRef.current) return;
-
-    const img = imageRef.current;
-    const canvas = canvasRef.current;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-
-    const scaleX = img.naturalWidth / img.width;
-    const scaleY = img.naturalHeight / img.height;
-
-    canvas.width = cropArea.width * scaleX;
-    canvas.height = cropArea.height * scaleY;
-
-    ctx.drawImage(
-      img,
-      cropArea.x * scaleX,
-      cropArea.y * scaleY,
-      cropArea.width * scaleX,
-      cropArea.height * scaleY,
-      0,
-      0,
-      canvas.width,
-      canvas.height
-    );
-
-    canvas.toBlob((blob) => {
-      if (blob) {
-        const url = createSafeObjectURL(blob);
-        setImage(prev => {
-          if (prev && prev !== originalImage) revokeSafeObjectURL(prev);
-          return url;
-        });
-        setIsCropping(false);
-        setCropArea(null);
-      }
-    }, "image/png");
-  };
 
   const downloadImage = () => {
     if (!image) return;
-    const dateStamp = new Date().toLocaleDateString('en-CA');
+    const dateStamp = new Date().toLocaleDateString("en-CA");
     const link = document.createElement("a");
     link.href = image;
     link.download = `delphitools-paste-image-${dateStamp}.png`;
@@ -283,18 +101,17 @@ export function PasteImageTool() {
   const resetImage = () => {
     if (image && image !== originalImage) revokeSafeObjectURL(image);
     setImage(originalImage);
-    setIsCropping(false);
-    setCropArea(null);
+    cancelCropping();
   };
 
   const clearImage = () => {
+    cancelCropping();
     if (image) revokeSafeObjectURL(image);
-    if (originalImage && originalImage !== image) revokeSafeObjectURL(originalImage);
-    
+    if (originalImage && originalImage !== image)
+      revokeSafeObjectURL(originalImage);
+
     setImage(null);
     setOriginalImage(null);
-    setIsCropping(false);
-    setCropArea(null);
   };
 
   return (
@@ -323,7 +140,11 @@ export function PasteImageTool() {
                 <Button onClick={applyCrop} size="sm">
                   <Check className="size-4 mr-2" /> Apply Crop
                 </Button>
-                <Button onClick={() => { setIsCropping(false); setCropArea(null); }} variant="outline" size="sm">
+                <Button
+                  onClick={cancelCropping}
+                  variant="outline"
+                  size="sm"
+                >
                   Cancel
                 </Button>
               </>
@@ -360,48 +181,12 @@ export function PasteImageTool() {
                 draggable={false}
               />
 
-              {isCropping && cropArea && (
-                <div
-                  className="absolute pointer-events-none"
-                  style={{
-                    left: cropArea.x,
-                    top: cropArea.y,
-                    width: cropArea.width,
-                    height: cropArea.height,
-                    boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.65)",
-                  }}
-                >
-                  <div className="absolute inset-0 grid grid-cols-3 grid-rows-3 border border-white/50">
-                    {Array.from({ length: 9 }).map((_, i) => (
-                      <div key={i} className="border border-white/30" />
-                    ))}
-                  </div>
-
-                  <div
-                    className="absolute inset-0 pointer-events-auto cursor-move"
-                    onMouseDown={(e) => handleDragStart(e, "move")}
-                    onTouchStart={(e) => handleDragStart(e, "move")}
-                  />
-
-                  <div className="absolute top-0 left-0 right-0 h-2 -translate-y-1/2 pointer-events-auto cursor-ns-resize" onMouseDown={(e) => handleDragStart(e, "n")} onTouchStart={(e) => handleDragStart(e, "n")} />
-                  <div className="absolute bottom-0 left-0 right-0 h-2 translate-y-1/2 pointer-events-auto cursor-ns-resize" onMouseDown={(e) => handleDragStart(e, "s")} onTouchStart={(e) => handleDragStart(e, "s")} />
-                  <div className="absolute top-0 bottom-0 left-0 w-2 -translate-x-1/2 pointer-events-auto cursor-ew-resize" onMouseDown={(e) => handleDragStart(e, "w")} onTouchStart={(e) => handleDragStart(e, "w")} />
-                  <div className="absolute top-0 bottom-0 right-0 w-2 translate-x-1/2 pointer-events-auto cursor-ew-resize" onMouseDown={(e) => handleDragStart(e, "e")} onTouchStart={(e) => handleDragStart(e, "e")} />
-
-                  <div className="absolute top-0 left-0 w-4 h-4 bg-white border border-border -translate-x-1/2 -translate-y-1/2 pointer-events-auto cursor-nwse-resize shadow-md" onMouseDown={(e) => handleDragStart(e, "nw")} onTouchStart={(e) => handleDragStart(e, "nw")} />
-                  <div className="absolute top-0 right-0 w-4 h-4 bg-white border border-border translate-x-1/2 -translate-y-1/2 pointer-events-auto cursor-nesw-resize shadow-md" onMouseDown={(e) => handleDragStart(e, "ne")} onTouchStart={(e) => handleDragStart(e, "ne")} />
-                  <div className="absolute bottom-0 left-0 w-4 h-4 bg-white border border-border -translate-x-1/2 translate-y-1/2 pointer-events-auto cursor-nesw-resize shadow-md" onMouseDown={(e) => handleDragStart(e, "sw")} onTouchStart={(e) => handleDragStart(e, "sw")} />
-                  <div className="absolute bottom-0 right-0 w-4 h-4 bg-white border border-border translate-x-1/2 translate-y-1/2 pointer-events-auto cursor-nwse-resize shadow-md" onMouseDown={(e) => handleDragStart(e, "se")} onTouchStart={(e) => handleDragStart(e, "se")} />
-
-                  {cropArea.width > 50 && cropArea.height > 30 && (
-                    <div className="absolute top-4 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground font-mono text-sm px-2 py-1 rounded shadow-sm whitespace-nowrap">
-                      {Math.round(cropArea.width * imageScale.x)}
-                      {" × "}
-                      {Math.round(cropArea.height * imageScale.y)} px
-                    </div>
-                  )}
-                </div>
-              )}
+              <PasteStyleCropOverlay
+                isCropping={isCropping}
+                cropArea={cropArea}
+                imageScale={imageScale}
+                onDragStart={handleDragStart}
+              />
             </div>
           </div>
         </div>

--- a/components/tools/paste-style-image-crop.tsx
+++ b/components/tools/paste-style-image-crop.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface PasteStyleCropArea {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type PasteStyleDragMode =
+  | "nw"
+  | "ne"
+  | "sw"
+  | "se"
+  | "n"
+  | "s"
+  | "e"
+  | "w"
+  | "move"
+  | null;
+
+export function usePasteStyleImageCrop(opts: {
+  imageRef: React.RefObject<HTMLImageElement | null>;
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  onCroppedBlob: (blob: Blob) => void;
+}) {
+  const { imageRef, canvasRef, onCroppedBlob } = opts;
+
+  const [isCropping, setIsCropping] = useState(false);
+  const [cropArea, setCropArea] = useState<PasteStyleCropArea | null>(null);
+  const [dragMode, setDragMode] = useState<PasteStyleDragMode>(null);
+  const [dragStart, setDragStart] = useState<{
+    mouseX: number;
+    mouseY: number;
+    initialCrop: PasteStyleCropArea;
+  } | null>(null);
+  const [imageScale, setImageScale] = useState({ x: 1, y: 1 });
+
+  const rafRef = useRef<number | null>(null);
+  const resizeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (resizeTimeoutRef.current) clearTimeout(resizeTimeoutRef.current);
+      resizeTimeoutRef.current = setTimeout(() => {
+        if (isCropping) {
+          setIsCropping(false);
+          setCropArea(null);
+        }
+      }, 150);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      if (resizeTimeoutRef.current) clearTimeout(resizeTimeoutRef.current);
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [isCropping]);
+
+  const startCropping = useCallback(() => {
+    const el = imageRef.current;
+    if (el) {
+      setCropArea({
+        x: 0,
+        y: 0,
+        width: el.width,
+        height: el.height,
+      });
+      setImageScale({
+        x: el.naturalWidth / el.width,
+        y: el.naturalHeight / el.height,
+      });
+      setIsCropping(true);
+    }
+  }, [imageRef]);
+
+  const cancelCropping = useCallback(() => {
+    setIsCropping(false);
+    setCropArea(null);
+  }, []);
+
+  const handleDragStart = (
+    e: React.MouseEvent | React.TouchEvent,
+    mode: PasteStyleDragMode,
+  ) => {
+    if (e.type !== "touchstart") {
+      e.preventDefault();
+    }
+    e.stopPropagation();
+    if (!cropArea) return;
+
+    const clientX = "touches" in e ? e.touches[0].clientX : e.clientX;
+    const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
+
+    setDragMode(mode);
+    setDragStart({
+      mouseX: clientX,
+      mouseY: clientY,
+      initialCrop: { ...cropArea },
+    });
+  };
+
+  const handleDragMove = useCallback(
+    (e: MouseEvent | TouchEvent) => {
+      if (!dragMode || !dragStart || !imageRef.current) return;
+      if (e.cancelable) e.preventDefault();
+
+      const clientX =
+        "touches" in e ? e.touches[0].clientX : (e as MouseEvent).clientX;
+      const clientY =
+        "touches" in e ? e.touches[0].clientY : (e as MouseEvent).clientY;
+
+      const dx = clientX - dragStart.mouseX;
+      const dy = clientY - dragStart.mouseY;
+
+      const { initialCrop } = dragStart;
+      let newX = initialCrop.x;
+      let newY = initialCrop.y;
+      let newW = initialCrop.width;
+      let newH = initialCrop.height;
+
+      const minSize = 20;
+      const maxW = imageRef.current.width;
+      const maxH = imageRef.current.height;
+
+      if (dragMode === "move") {
+        newX = Math.max(0, Math.min(newX + dx, maxW - newW));
+        newY = Math.max(0, Math.min(newY + dy, maxH - newH));
+      } else {
+        if (dragMode.includes("n")) {
+          const proposedY = newY + dy;
+          const proposedH = newH - dy;
+          if (proposedH >= minSize && proposedY >= 0) {
+            newY = proposedY;
+            newH = proposedH;
+          } else if (proposedY < 0) {
+            newY = 0;
+            newH = initialCrop.y + initialCrop.height;
+          }
+        } else if (dragMode.includes("s")) {
+          const proposedH = newH + dy;
+          if (proposedH >= minSize && newY + proposedH <= maxH) {
+            newH = proposedH;
+          } else if (newY + proposedH > maxH) {
+            newH = maxH - newY;
+          }
+        }
+
+        if (dragMode.includes("w")) {
+          const proposedX = newX + dx;
+          const proposedW = newW - dx;
+          if (proposedW >= minSize && proposedX >= 0) {
+            newX = proposedX;
+            newW = proposedW;
+          } else if (proposedX < 0) {
+            newX = 0;
+            newW = initialCrop.x + initialCrop.width;
+          }
+        } else if (dragMode.includes("e")) {
+          const proposedW = newW + dx;
+          if (proposedW >= minSize && newX + proposedW <= maxW) {
+            newW = proposedW;
+          } else if (newX + proposedW > maxW) {
+            newW = maxW - newX;
+          }
+        }
+      }
+
+      if (rafRef.current !== null) return;
+      rafRef.current = requestAnimationFrame(() => {
+        setCropArea({ x: newX, y: newY, width: newW, height: newH });
+        rafRef.current = null;
+      });
+    },
+    [dragMode, dragStart, imageRef],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    setDragMode(null);
+    setDragStart(null);
+  }, []);
+
+  useEffect(() => {
+    if (dragMode) {
+      window.addEventListener("mousemove", handleDragMove);
+      window.addEventListener("mouseup", handleDragEnd);
+      window.addEventListener("touchmove", handleDragMove, { passive: false });
+      window.addEventListener("touchend", handleDragEnd);
+      return () => {
+        window.removeEventListener("mousemove", handleDragMove);
+        window.removeEventListener("mouseup", handleDragEnd);
+        window.removeEventListener("touchmove", handleDragMove);
+        window.removeEventListener("touchend", handleDragEnd);
+      };
+    }
+  }, [dragMode, handleDragMove, handleDragEnd]);
+
+  const applyCrop = useCallback(() => {
+    if (!cropArea || !imageRef.current || !canvasRef.current) return;
+
+    const img = imageRef.current;
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const scaleX = img.naturalWidth / img.width;
+    const scaleY = img.naturalHeight / img.height;
+
+    canvas.width = cropArea.width * scaleX;
+    canvas.height = cropArea.height * scaleY;
+
+    ctx.drawImage(
+      img,
+      cropArea.x * scaleX,
+      cropArea.y * scaleY,
+      cropArea.width * scaleX,
+      cropArea.height * scaleY,
+      0,
+      0,
+      canvas.width,
+      canvas.height,
+    );
+
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          onCroppedBlob(blob);
+          setIsCropping(false);
+          setCropArea(null);
+        }
+      },
+      "image/png",
+    );
+  }, [canvasRef, cropArea, imageRef, onCroppedBlob]);
+
+  return {
+    isCropping,
+    cropArea,
+    imageScale,
+    startCropping,
+    cancelCropping,
+    applyCrop,
+    handleDragStart,
+  };
+}
+
+export function PasteStyleCropOverlay({
+  isCropping,
+  cropArea,
+  imageScale,
+  onDragStart,
+}: {
+  isCropping: boolean;
+  cropArea: PasteStyleCropArea | null;
+  imageScale: { x: number; y: number };
+  onDragStart: (
+    e: React.MouseEvent | React.TouchEvent,
+    mode: Exclude<PasteStyleDragMode, null>,
+  ) => void;
+}) {
+  if (!isCropping || !cropArea) return null;
+
+  return (
+    <div
+      className="absolute pointer-events-none"
+      style={{
+        left: cropArea.x,
+        top: cropArea.y,
+        width: cropArea.width,
+        height: cropArea.height,
+        boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.65)",
+      }}
+    >
+      <div className="absolute inset-0 grid grid-cols-3 grid-rows-3 border border-white/50">
+        {Array.from({ length: 9 }).map((_, i) => (
+          <div key={i} className="border border-white/30" />
+        ))}
+      </div>
+
+      <div
+        className="absolute inset-0 pointer-events-auto cursor-move"
+        onMouseDown={(e) => onDragStart(e, "move")}
+        onTouchStart={(e) => onDragStart(e, "move")}
+      />
+
+      <div
+        className="absolute top-0 left-0 right-0 h-2 -translate-y-1/2 pointer-events-auto cursor-ns-resize"
+        onMouseDown={(e) => onDragStart(e, "n")}
+        onTouchStart={(e) => onDragStart(e, "n")}
+      />
+      <div
+        className="absolute bottom-0 left-0 right-0 h-2 translate-y-1/2 pointer-events-auto cursor-ns-resize"
+        onMouseDown={(e) => onDragStart(e, "s")}
+        onTouchStart={(e) => onDragStart(e, "s")}
+      />
+      <div
+        className="absolute top-0 bottom-0 left-0 w-2 -translate-x-1/2 pointer-events-auto cursor-ew-resize"
+        onMouseDown={(e) => onDragStart(e, "w")}
+        onTouchStart={(e) => onDragStart(e, "w")}
+      />
+      <div
+        className="absolute top-0 bottom-0 right-0 w-2 translate-x-1/2 pointer-events-auto cursor-ew-resize"
+        onMouseDown={(e) => onDragStart(e, "e")}
+        onTouchStart={(e) => onDragStart(e, "e")}
+      />
+
+      <div
+        className="absolute top-0 left-0 w-4 h-4 bg-white border border-border -translate-x-1/2 -translate-y-1/2 pointer-events-auto cursor-nwse-resize shadow-md"
+        onMouseDown={(e) => onDragStart(e, "nw")}
+        onTouchStart={(e) => onDragStart(e, "nw")}
+      />
+      <div
+        className="absolute top-0 right-0 w-4 h-4 bg-white border border-border translate-x-1/2 -translate-y-1/2 pointer-events-auto cursor-nesw-resize shadow-md"
+        onMouseDown={(e) => onDragStart(e, "ne")}
+        onTouchStart={(e) => onDragStart(e, "ne")}
+      />
+      <div
+        className="absolute bottom-0 left-0 w-4 h-4 bg-white border border-border -translate-x-1/2 translate-y-1/2 pointer-events-auto cursor-nesw-resize shadow-md"
+        onMouseDown={(e) => onDragStart(e, "sw")}
+        onTouchStart={(e) => onDragStart(e, "sw")}
+      />
+      <div
+        className="absolute bottom-0 right-0 w-4 h-4 bg-white border border-border translate-x-1/2 translate-y-1/2 pointer-events-auto cursor-nwse-resize shadow-md"
+        onMouseDown={(e) => onDragStart(e, "se")}
+        onTouchStart={(e) => onDragStart(e, "se")}
+      />
+
+      {cropArea.width > 50 && cropArea.height > 30 && (
+        <div className="absolute top-4 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground font-mono text-sm px-2 py-1 rounded shadow-sm whitespace-nowrap">
+          {Math.round(cropArea.width * imageScale.x)}
+          {" × "}
+          {Math.round(cropArea.height * imageScale.y)} px
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -45,6 +45,7 @@ import {
   Wind,
   GitCompare,
   KeyRound,
+  ClipboardCopy,
 } from "lucide-react";
 
 export interface Tool {
@@ -239,6 +240,13 @@ export const toolCategories: ToolCategory[] = [
         description: "Paste and download an image from your clipboard",
         icon: ClipboardPaste,
         href: "/tools/paste-image",
+      },
+      {
+        id: "media-url-to-clipboard",
+        name: "Media url to clipboard",
+        description: "Copy media from a URL to your clipboard",
+        icon: ClipboardCopy,
+        href: "/tools/media-url-to-clipboard",
       },
       {
         id: "placeholder-genny",


### PR DESCRIPTION
﻿Adds a **Media url to clipboard** tool: paste an image URL, preview it, optionally crop, then copy a PNG to the clipboard (alongside the existing Paste Image flow).

## What's in it

- New client-side tool: http(s) fetch with basic validation, decode check, shared crop overlay, reset to original, copy as PNG via the Clipboard API
- Extracted `usePasteStyleImageCrop` and `PasteStyleCropOverlay` into `paste-style-image-crop.tsx`; **Paste Image** refactored to use the shared hook (same behaviour, less duplication)
- Tool registered in `lib/tools.ts` and wired via dynamic import in `app/tools/[toolId]/page.tsx`

## Invariants

- Fetch is subject to normal browser CORS rules; clipboard write requires supported APIs
- No new npm dependencies

## Testing

- `npm run build` (static export / TypeScript clean)
- Manual smoke on `/tools/paste-image` and `/tools/media-url-to-clipboard`
