### PR TITLE
feat(qr-generator): optimize WiFi QR code generation by adding WiFi form with hidden ssid option

### DIFF
--- a/components/tools/qr-generator.tsx
+++ b/components/tools/qr-generator.tsx
@@ -175,7 +175,7 @@ export function QrGeneratorTool() {
   const [wifiData, setWifiData] = useState<WiFiFormData>({
     ssid: "",
     password: "",
-    securityType: "WPA",
+    securityType: "nopass",
     isHidden: false,
   });
 

--- a/components/tools/qr-generator.tsx
+++ b/components/tools/qr-generator.tsx
@@ -38,8 +38,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Switch } from "@/components/ui/switch";
 import { useFilePaste } from "@/hooks/use-file-paste";
-import { WiFiForm, type WiFiFormData } from "./wifi-form";
+import { WiFiForm, generateWiFiString, type WiFiFormData } from "./wifi-form";
 
 // Types
 type DotType =
@@ -155,6 +156,57 @@ const defaultVCard: VCardData = {
   address: "",
 };
 
+const INFO_FONT =
+  'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif';
+
+const escapeXml = (value: string) =>
+  value.replace(/[&<>'"]/g, (c) =>
+    c === "&"
+      ? "&amp;"
+      : c === "<"
+        ? "&lt;"
+        : c === ">"
+          ? "&gt;"
+          : c === "'"
+            ? "&apos;"
+            : "&quot;"
+  );
+
+// Word-wrap for the exported info block; hard-breaks words wider than the
+// line (long URLs) so text never overflows the QR width
+const wrapText = (
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number
+): string[] => {
+  const lines: string[] = [];
+  let line = "";
+  for (const word of text.split(/\s+/)) {
+    let chunk = word;
+    while (ctx.measureText(chunk).width > maxWidth && chunk.length > 1) {
+      let cut = chunk.length - 1;
+      while (cut > 1 && ctx.measureText(chunk.slice(0, cut)).width > maxWidth) {
+        cut--;
+      }
+      if (line) {
+        lines.push(line);
+        line = "";
+      }
+      lines.push(chunk.slice(0, cut));
+      chunk = chunk.slice(cut);
+    }
+    const tryLine = line ? `${line} ${chunk}` : chunk;
+    if (!line || ctx.measureText(tryLine).width <= maxWidth) {
+      line = tryLine;
+    } else {
+      lines.push(line);
+      line = chunk;
+    }
+  }
+  if (line) lines.push(line);
+  return lines;
+};
+
 export function QrGeneratorTool() {
   // Main state
   const [activeTab, setActiveTab] = useState<"single" | "batch" | "vcard" | "wifi">(
@@ -165,6 +217,7 @@ export function QrGeneratorTool() {
   const [options, setOptions] = useState<QROptions>(defaultQROptions);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
 
   const [generating, setGenerating] = useState(false);
 
@@ -264,11 +317,17 @@ export function QrGeneratorTool() {
 
   // Generate QR code using qr-code-styling
   const generateQRCode = useCallback(async () => {
-    if (!content.trim() && activeTab !== "vcard" && activeTab !== "wifi") return;
-
     const actualContent =
-      activeTab === "vcard" ? generateVCardString(vCardData) : content;
-    if (!actualContent.trim()) return;
+      activeTab === "vcard"
+        ? generateVCardString(vCardData)
+        : activeTab === "wifi"
+          ? generateWiFiString(wifiData)
+          : content;
+    if (!actualContent.trim()) {
+      setQrDataUrl(null);
+      qrCodeInstance.current = null;
+      return;
+    }
 
     setGenerating(true);
 
@@ -332,7 +391,7 @@ export function QrGeneratorTool() {
     } finally {
       setGenerating(false);
     }
-  }, [content, size, options, activeTab, vCardData, generateVCardString]);
+  }, [content, size, options, activeTab, vCardData, wifiData, generateVCardString]);
 
   // Regenerate when dependencies change
   useEffect(() => {
@@ -383,19 +442,133 @@ export function QrGeneratorTool() {
     if (file) processLogoFile(file);
   };
 
+  // Plaintext details shown under the QR when "Add information" is on;
+  // entries without a label render as a bare line
+  const infoEntries: { label?: string; value: string }[] = (
+    activeTab === "wifi"
+      ? [
+          { label: "Network", value: wifiData.ssid.trim() },
+          ...(wifiData.securityType !== "nopass"
+            ? [{ label: "Password", value: wifiData.password }]
+            : []),
+          ...(wifiData.isHidden ? [{ value: "Hidden network" }] : []),
+        ]
+      : activeTab === "vcard"
+        ? [
+            {
+              label: "Name",
+              value: `${vCardData.firstName} ${vCardData.lastName}`.trim(),
+            },
+            { label: "Organization", value: vCardData.organization },
+            { label: "Job Title", value: vCardData.title },
+            { label: "Email", value: vCardData.email },
+            { label: "Phone", value: vCardData.phone },
+            { label: "Website", value: vCardData.website },
+            { label: "Address", value: vCardData.address },
+          ]
+        : [{ label: "Content", value: content.trim() }]
+  ).filter((entry) => entry.value);
+
+  const includeInfo = showInfo && infoEntries.length > 0;
+
+  const infoTexts = infoEntries.map((entry) =>
+    entry.label ? `${entry.label}: ${entry.value}` : entry.value
+  );
+
+  // Measure and wrap the info block in the QR's coordinate space; scale
+  // converts to bitmap pixels for PNG export
+  const buildInfoLayout = (scale: number) => {
+    const ctx = document.createElement("canvas").getContext("2d");
+    if (!ctx) return null;
+    const fontSize = Math.max(13, Math.round(size * 0.055)) * scale;
+    const lineHeight = Math.round(fontSize * 1.5);
+    const maxWidth = size * 0.88 * scale;
+    ctx.font = `500 ${fontSize}px ${INFO_FONT}`;
+    const lines = infoTexts.flatMap((text) => wrapText(ctx, text, maxWidth));
+    return {
+      fontSize,
+      lineHeight,
+      lines,
+      blockHeight: lines.length * lineHeight + fontSize,
+    };
+  };
+
+  const composeInfoPng = async (): Promise<Blob | null> => {
+    const qr = qrCodeInstance.current;
+    if (!qr) return null;
+    const raw = await qr.getRawData("png");
+    if (!(raw instanceof Blob)) return null;
+    const bitmap = await createImageBitmap(raw);
+    const layout = buildInfoLayout(bitmap.width / size);
+    if (!layout) return null;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height + layout.blockHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+
+    if (!options.transparentBg) {
+      ctx.fillStyle = options.backgroundColor;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+    ctx.drawImage(bitmap, 0, 0);
+    ctx.fillStyle = options.foregroundColor;
+    ctx.font = `500 ${layout.fontSize}px ${INFO_FONT}`;
+    ctx.textAlign = "center";
+    layout.lines.forEach((line, i) => {
+      ctx.fillText(
+        line,
+        canvas.width / 2,
+        bitmap.height + (i + 0.75) * layout.lineHeight
+      );
+    });
+    return new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
+  };
+
+  const composeInfoSvg = async (): Promise<Blob | null> => {
+    const qr = qrCodeInstance.current;
+    if (!qr) return null;
+    const raw = await qr.getRawData("svg");
+    if (!(raw instanceof Blob)) return null;
+    const qrSvg = (await raw.text()).replace(/<\?xml[^?]*\?>/, "");
+    const layout = buildInfoLayout(1);
+    if (!layout) return null;
+
+    const totalHeight = size + layout.blockHeight;
+    const background = options.transparentBg
+      ? ""
+      : `<rect width="100%" height="100%" fill="${options.backgroundColor}"/>`;
+    const textEls = layout.lines
+      .map(
+        (line, i) =>
+          `<text x="${size / 2}" y="${size + (i + 0.75) * layout.lineHeight}" text-anchor="middle" fill="${options.foregroundColor}" font-family='${INFO_FONT}' font-size="${layout.fontSize}" font-weight="500">${escapeXml(line)}</text>`
+      )
+      .join("");
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${totalHeight}" viewBox="0 0 ${size} ${totalHeight}">${background}${qrSvg}${textEls}</svg>`;
+    return new Blob([svg], { type: "image/svg+xml" });
+  };
+
   // Download functions
   const downloadCode = async (format: "png" | "svg") => {
-    if (!qrCodeInstance.current && !qrDataUrl) return;
+    const qr = qrCodeInstance.current;
+    if (!qr) return;
 
     const filename = `qr-code-${Date.now()}`;
 
-    if (qrCodeInstance.current) {
-      if (format === "svg") {
-        qrCodeInstance.current.download({ name: filename, extension: "svg" });
-      } else {
-        qrCodeInstance.current.download({ name: filename, extension: "png" });
-      }
+    if (!includeInfo) {
+      qr.download({ name: filename, extension: format });
+      return;
     }
+
+    const blob =
+      format === "png" ? await composeInfoPng() : await composeInfoSvg();
+    if (!blob) return;
+    const link = document.createElement("a");
+    link.href = URL.createObjectURL(blob);
+    link.download = `${filename}.${format}`;
+    link.click();
+    URL.revokeObjectURL(link.href);
   };
 
   // Copy to clipboard
@@ -403,8 +576,10 @@ export function QrGeneratorTool() {
     if (!qrDataUrl) return;
 
     try {
-      const response = await fetch(qrDataUrl);
-      const blob = await response.blob();
+      const blob = includeInfo
+        ? await composeInfoPng()
+        : await (await fetch(qrDataUrl)).blob();
+      if (!blob) return;
       await navigator.clipboard.write([
         new ClipboardItem({ "image/png": blob }),
       ]);
@@ -566,6 +741,7 @@ export function QrGeneratorTool() {
     { label: "URL", placeholder: "https://example.com" },
     { label: "Email", placeholder: "mailto:hello@example.com" },
     { label: "Phone", placeholder: "tel:+1234567890" },
+    { label: "WiFi", placeholder: "WIFI:T:WPA;S:NetworkName;P:password;;" },
     { label: "SMS", placeholder: "sms:+1234567890?body=Hello" },
     { label: "Geo", placeholder: "geo:40.7128,-74.0060" },
   ];
@@ -634,11 +810,7 @@ export function QrGeneratorTool() {
 
           {/* WiFi QR Generator */}
           <TabsContent value="wifi" className="space-y-4 mt-4">
-            <WiFiForm
-              data={wifiData}
-              onChange={setWifiData}
-              onQRStringChange={setContent}
-            />
+            <WiFiForm data={wifiData} onChange={setWifiData} />
           </TabsContent>
 
           {/* vCard Builder */}
@@ -831,7 +1003,22 @@ export function QrGeneratorTool() {
           <div className="grid lg:grid-cols-2 gap-6">
             {/* Preview */}
             <div className="space-y-4">
-              <Label className="font-bold text-lg">Preview</Label>
+              <div className="flex items-center justify-between">
+                <Label className="font-bold text-lg">Preview</Label>
+                <div className="flex items-center gap-2">
+                  <Switch
+                    id="show-info"
+                    checked={showInfo}
+                    onCheckedChange={setShowInfo}
+                  />
+                  <Label
+                    htmlFor="show-info"
+                    className="text-sm font-normal text-muted-foreground"
+                  >
+                    Add information
+                  </Label>
+                </div>
+              </div>
               <div
                 className={`border-4 border-card rounded-xl p-4 flex items-center justify-center min-h-[320px] ${options.transparentBg ? "bg-[repeating-conic-gradient(#e5e7eb_0%_25%,transparent_0%_50%)] bg-[length:16px_16px]" : ""}`}
                 style={options.transparentBg ? undefined : { backgroundColor: options.backgroundColor }}
@@ -839,16 +1026,36 @@ export function QrGeneratorTool() {
                 {generating ? (
                   <Loader2 className="size-8 animate-spin text-muted-foreground" />
                 ) : qrDataUrl ? (
-                  <img
-                    src={qrDataUrl}
-                    alt="QR Code"
-                    width={size}
-                    height={size}
-                    className="block"
-                  />
+                  <div className="flex max-w-full flex-col items-center">
+                    <img
+                      src={qrDataUrl}
+                      alt="QR Code"
+                      width={size}
+                      height={size}
+                      className="block"
+                    />
+                    {includeInfo && (
+                      <div
+                        className="max-w-full space-y-1 px-4 pb-2 text-center"
+                        style={{ color: options.foregroundColor }}
+                      >
+                        {infoTexts.map((text) => (
+                          <p key={text} className="break-all text-sm font-medium">
+                            {text}
+                          </p>
+                        ))}
+                      </div>
+                    )}
+                  </div>
                 ) : (
                   <div className="text-center text-muted-foreground">
-                    <p>Enter content to generate QR code</p>
+                    <p>
+                      {activeTab === "wifi"
+                        ? "Enter network details to generate QR code"
+                        : activeTab === "vcard"
+                          ? "Fill in contact details to generate QR code"
+                          : "Enter content to generate QR code"}
+                    </p>
                   </div>
                 )}
               </div>
@@ -1158,20 +1365,24 @@ export function QrGeneratorTool() {
                             className="font-mono flex-1"
                           />
                         </div>
-                        <label className="flex items-center gap-2 text-sm cursor-pointer">
-                          <input
-                            type="checkbox"
+                        <div className="flex items-center gap-2">
+                          <Switch
+                            id="transparent-bg"
                             checked={options.transparentBg}
-                            onChange={(e) =>
+                            onCheckedChange={(checked) =>
                               setOptions((prev) => ({
                                 ...prev,
-                                transparentBg: e.target.checked,
+                                transparentBg: checked,
                               }))
                             }
-                            className="rounded"
                           />
-                          Transparent background
-                        </label>
+                          <Label
+                            htmlFor="transparent-bg"
+                            className="text-sm font-normal"
+                          >
+                            Transparent background
+                          </Label>
+                        </div>
                       </div>
                     </div>
                   </AccordionContent>

--- a/components/tools/qr-generator.tsx
+++ b/components/tools/qr-generator.tsx
@@ -566,7 +566,6 @@ export function QrGeneratorTool() {
     { label: "URL", placeholder: "https://example.com" },
     { label: "Email", placeholder: "mailto:hello@example.com" },
     { label: "Phone", placeholder: "tel:+1234567890" },
-    { label: "WiFi", placeholder: "WIFI:T:WPA;S:NetworkName;P:password;;" },
     { label: "SMS", placeholder: "sms:+1234567890?body=Hello" },
     { label: "Geo", placeholder: "geo:40.7128,-74.0060" },
   ];

--- a/components/tools/qr-generator.tsx
+++ b/components/tools/qr-generator.tsx
@@ -39,6 +39,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useFilePaste } from "@/hooks/use-file-paste";
+import { WiFiForm, type WiFiFormData } from "./wifi-form";
 
 // Types
 type DotType =
@@ -156,7 +157,7 @@ const defaultVCard: VCardData = {
 
 export function QrGeneratorTool() {
   // Main state
-  const [activeTab, setActiveTab] = useState<"single" | "batch" | "vcard">(
+  const [activeTab, setActiveTab] = useState<"single" | "batch" | "vcard" | "wifi">(
     "single"
   );
   const [content, setContent] = useState("");
@@ -169,6 +170,14 @@ export function QrGeneratorTool() {
 
   // vCard state
   const [vCardData, setVCardData] = useState<VCardData>(defaultVCard);
+
+  // WiFi form state
+  const [wifiData, setWifiData] = useState<WiFiFormData>({
+    ssid: "",
+    password: "",
+    securityType: "WPA",
+    isHidden: false,
+  });
 
   // Batch state
   const [batchItems, setBatchItems] = useState<BatchItem[]>([]);
@@ -255,7 +264,7 @@ export function QrGeneratorTool() {
 
   // Generate QR code using qr-code-styling
   const generateQRCode = useCallback(async () => {
-    if (!content.trim() && activeTab !== "vcard") return;
+    if (!content.trim() && activeTab !== "vcard" && activeTab !== "wifi") return;
 
     const actualContent =
       activeTab === "vcard" ? generateVCardString(vCardData) : content;
@@ -570,8 +579,9 @@ export function QrGeneratorTool() {
           value={activeTab}
           onValueChange={(v) => setActiveTab(v as typeof activeTab)}
         >
-          <TabsList className="grid w-full grid-cols-3">
+          <TabsList className="grid w-full grid-cols-4">
             <TabsTrigger value="single">Single</TabsTrigger>
+            <TabsTrigger value="wifi">WiFi QR</TabsTrigger>
             <TabsTrigger value="vcard">vCard Builder</TabsTrigger>
             <TabsTrigger value="batch">Batch Mode</TabsTrigger>
           </TabsList>
@@ -621,6 +631,15 @@ export function QrGeneratorTool() {
                 </Button>
               ))}
             </div>
+          </TabsContent>
+
+          {/* WiFi QR Generator */}
+          <TabsContent value="wifi" className="space-y-4 mt-4">
+            <WiFiForm
+              data={wifiData}
+              onChange={setWifiData}
+              onQRStringChange={setContent}
+            />
           </TabsContent>
 
           {/* vCard Builder */}

--- a/components/tools/wifi-form.tsx
+++ b/components/tools/wifi-form.tsx
@@ -11,7 +11,7 @@ import {
 export interface WiFiFormData {
   ssid: string;
   password: string;
-  securityType: "WPA" | "WEP" | "nopass";
+  securityType: "nopass" | "WPA" | "WEP" ;
   isHidden: boolean;
 }
 
@@ -66,6 +66,7 @@ export function WiFiForm({ data, onChange, onQRStringChange }: WiFiFormProps) {
         <Label htmlFor="ssid">Network Name (SSID)</Label>
         <Input
           id="ssid"
+          type="text"
           value={data.ssid}
           onChange={(e) => handleFieldChange("ssid", e.target.value)}
           placeholder="My WiFi Network"
@@ -79,7 +80,7 @@ export function WiFiForm({ data, onChange, onQRStringChange }: WiFiFormProps) {
           onValueChange={(value) =>
             handleFieldChange(
               "securityType",
-              value as "WPA" | "WEP" | "nopass"
+              value as WiFiFormData["securityType"]
             )
           }
         >
@@ -87,9 +88,9 @@ export function WiFiForm({ data, onChange, onQRStringChange }: WiFiFormProps) {
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="WPA">WPA / WPA2 / WPA3</SelectItem>
-            <SelectItem value="WEP">WEP (Legacy)</SelectItem>
-            <SelectItem value="nopass">Open (No Password)</SelectItem>
+            <SelectItem value="nopass">No password</SelectItem>
+            <SelectItem value="WPA">WPA/WPA2</SelectItem>
+            <SelectItem value="WEP">WEP</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -99,7 +100,7 @@ export function WiFiForm({ data, onChange, onQRStringChange }: WiFiFormProps) {
           <Label htmlFor="password">Password</Label>
           <Input
             id="password"
-            type="password"
+            type="text"
             value={data.password}
             onChange={(e) => handleFieldChange("password", e.target.value)}
             placeholder="Enter WiFi password"

--- a/components/tools/wifi-form.tsx
+++ b/components/tools/wifi-form.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -7,57 +12,57 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 
 export interface WiFiFormData {
   ssid: string;
   password: string;
-  securityType: "nopass" | "WPA" | "WEP" ;
+  securityType: "nopass" | "WPA" | "WEP";
   isHidden: boolean;
+}
+
+// The ZXing WIFI: spec requires escaping \ ; , " : — unescaped quotes make
+// scanners treat the value as hex/quoted rather than literal text
+function escapeWiFiValue(value: string): string {
+  return value.replace(/[\\;,":]/g, "\\$&");
+}
+
+// Format: WIFI:T:{security};S:{ssid};P:{password};H:true;;
+// Returns "" while the form is incomplete — a secured network without a
+// password would encode an unjoinable QR
+export function generateWiFiString(data: WiFiFormData): string {
+  const { ssid, password, securityType, isHidden } = data;
+
+  if (!ssid.trim()) return "";
+  if (securityType !== "nopass" && !password) return "";
+
+  let wifiString = `WIFI:T:${securityType};S:${escapeWiFiValue(ssid)}`;
+
+  if (securityType !== "nopass") {
+    wifiString += `;P:${escapeWiFiValue(password)}`;
+  }
+
+  if (isHidden) {
+    wifiString += ";H:true";
+  }
+
+  return wifiString + ";;";
 }
 
 interface WiFiFormProps {
   data: WiFiFormData;
   onChange: (data: WiFiFormData) => void;
-  onQRStringChange: (qrString: string) => void;
 }
 
-export function WiFiForm({ data, onChange, onQRStringChange }: WiFiFormProps) {
+export function WiFiForm({ data, onChange }: WiFiFormProps) {
+  const [showPassword, setShowPassword] = useState(false);
+  const secured = data.securityType !== "nopass";
+
   const handleFieldChange = (
     field: keyof WiFiFormData,
     value: string | boolean
   ) => {
-    const updatedData = { ...data, [field]: value };
-    onChange(updatedData);
-    // Generate and emit the WiFi QR string
-    generateAndEmitQRString(updatedData);
-  };
-
-  const generateAndEmitQRString = (formData: WiFiFormData) => {
-    const { ssid, password, securityType, isHidden } = formData;
-
-    if (!ssid) {
-      onQRStringChange("");
-      return;
-    }
-
-    // Escape special characters in SSID and password
-    const escapedSSID = ssid.replace(/[;:,\\]/g, "\\$&");
-    const escapedPassword = password.replace(/[;:,\\]/g, "\\$&");
-
-    // Build WiFi string according to RFC standard
-    // Format: WIFI:T:{security};S:{ssid};P:{password};H:{hidden};;
-    let wifiString = `WIFI:T:${securityType};S:${escapedSSID}`;
-
-    if (securityType !== "nopass" && password) {
-      wifiString += `;P:${escapedPassword}`;
-    }
-
-    if (isHidden) {
-      wifiString += ";H:true";
-    }
-
-    wifiString += ";;";
-    onQRStringChange(wifiString);
+    onChange({ ...data, [field]: value });
   };
 
   return (
@@ -73,51 +78,80 @@ export function WiFiForm({ data, onChange, onQRStringChange }: WiFiFormProps) {
         />
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="securityType">Security Type</Label>
-        <Select
-          value={data.securityType}
-          onValueChange={(value) =>
-            handleFieldChange(
-              "securityType",
-              value as WiFiFormData["securityType"]
-            )
-          }
-        >
-          <SelectTrigger id="securityType">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="nopass">No password</SelectItem>
-            <SelectItem value="WPA">WPA/WPA2</SelectItem>
-            <SelectItem value="WEP">WEP</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="securityType">Security Type</Label>
+          <Select
+            value={data.securityType}
+            onValueChange={(value) =>
+              handleFieldChange(
+                "securityType",
+                value as WiFiFormData["securityType"]
+              )
+            }
+          >
+            <SelectTrigger id="securityType" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="nopass">No password</SelectItem>
+              <SelectItem value="WPA">WPA/WPA2</SelectItem>
+              <SelectItem value="WEP">WEP</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
 
-      {data.securityType !== "nopass" && (
         <div className="space-y-2">
           <Label htmlFor="password">Password</Label>
-          <Input
-            id="password"
-            type="text"
-            value={data.password}
-            onChange={(e) => handleFieldChange("password", e.target.value)}
-            placeholder="Enter WiFi password"
-          />
+          <div className="relative">
+            <Input
+              id="password"
+              type={showPassword ? "text" : "password"}
+              autoComplete="off"
+              disabled={!secured}
+              value={secured ? data.password : ""}
+              onChange={(e) => handleFieldChange("password", e.target.value)}
+              placeholder={secured ? "Enter WiFi password" : "Open network"}
+              className="pr-10"
+            />
+            {secured && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:bg-transparent"
+                onClick={() => setShowPassword((show) => !show)}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? (
+                  <EyeOff className="size-4" />
+                ) : (
+                  <Eye className="size-4" />
+                )}
+              </Button>
+            )}
+          </div>
+          {secured && data.ssid.trim() && !data.password && (
+            <p className="text-xs text-muted-foreground">
+              Enter the password to generate the QR code.
+            </p>
+          )}
         </div>
-      )}
+      </div>
 
-      <label className="flex items-center gap-2 text-sm cursor-pointer">
-        <input
+      <div className="flex items-center justify-between gap-4 rounded-lg border p-3">
+        <div className="space-y-0.5">
+          <Label htmlFor="isHidden">Hidden network</Label>
+          <p className="text-xs text-muted-foreground">
+            For networks that don&apos;t broadcast their SSID.
+          </p>
+        </div>
+        <Switch
           id="isHidden"
-          type="checkbox"
           checked={data.isHidden}
-          onChange={(e) => handleFieldChange("isHidden", e.target.checked)}
-          className="w-4 h-4 rounded border border-input"
+          onCheckedChange={(checked) => handleFieldChange("isHidden", checked)}
         />
-        <span className="font-medium">Hidden SSID</span>
-      </label>
+      </div>
     </div>
   );
 }

--- a/components/tools/wifi-form.tsx
+++ b/components/tools/wifi-form.tsx
@@ -1,0 +1,122 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export interface WiFiFormData {
+  ssid: string;
+  password: string;
+  securityType: "WPA" | "WEP" | "nopass";
+  isHidden: boolean;
+}
+
+interface WiFiFormProps {
+  data: WiFiFormData;
+  onChange: (data: WiFiFormData) => void;
+  onQRStringChange: (qrString: string) => void;
+}
+
+export function WiFiForm({ data, onChange, onQRStringChange }: WiFiFormProps) {
+  const handleFieldChange = (
+    field: keyof WiFiFormData,
+    value: string | boolean
+  ) => {
+    const updatedData = { ...data, [field]: value };
+    onChange(updatedData);
+    // Generate and emit the WiFi QR string
+    generateAndEmitQRString(updatedData);
+  };
+
+  const generateAndEmitQRString = (formData: WiFiFormData) => {
+    const { ssid, password, securityType, isHidden } = formData;
+
+    if (!ssid) {
+      onQRStringChange("");
+      return;
+    }
+
+    // Escape special characters in SSID and password
+    const escapedSSID = ssid.replace(/[;:,\\]/g, "\\$&");
+    const escapedPassword = password.replace(/[;:,\\]/g, "\\$&");
+
+    // Build WiFi string according to RFC standard
+    // Format: WIFI:T:{security};S:{ssid};P:{password};H:{hidden};;
+    let wifiString = `WIFI:T:${securityType};S:${escapedSSID}`;
+
+    if (securityType !== "nopass" && password) {
+      wifiString += `;P:${escapedPassword}`;
+    }
+
+    if (isHidden) {
+      wifiString += ";H:true";
+    }
+
+    wifiString += ";;";
+    onQRStringChange(wifiString);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="ssid">Network Name (SSID)</Label>
+        <Input
+          id="ssid"
+          value={data.ssid}
+          onChange={(e) => handleFieldChange("ssid", e.target.value)}
+          placeholder="My WiFi Network"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="securityType">Security Type</Label>
+        <Select
+          value={data.securityType}
+          onValueChange={(value) =>
+            handleFieldChange(
+              "securityType",
+              value as "WPA" | "WEP" | "nopass"
+            )
+          }
+        >
+          <SelectTrigger id="securityType">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="WPA">WPA / WPA2 / WPA3</SelectItem>
+            <SelectItem value="WEP">WEP (Legacy)</SelectItem>
+            <SelectItem value="nopass">Open (No Password)</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {data.securityType !== "nopass" && (
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            value={data.password}
+            onChange={(e) => handleFieldChange("password", e.target.value)}
+            placeholder="Enter WiFi password"
+          />
+        </div>
+      )}
+
+      <label className="flex items-center gap-2 text-sm cursor-pointer">
+        <input
+          id="isHidden"
+          type="checkbox"
+          checked={data.isHidden}
+          onChange={(e) => handleFieldChange("isHidden", e.target.checked)}
+          className="w-4 h-4 rounded border border-input"
+        />
+        <span className="font-medium">Hidden SSID</span>
+      </label>
+    </div>
+  );
+}

--- a/scripts/build-shavian-dict.ts
+++ b/scripts/build-shavian-dict.ts
@@ -37,7 +37,7 @@ function main() {
   for (const line of lines) {
     const parts = line.split(/\s+/);
     if (parts.length < 2) continue;
-    let word = parts[0].toLowerCase();
+    const word = parts[0].toLowerCase();
     // Skip variant markers like "read(2)"
     if (word.includes("(")) continue;
     // Skip words with non-alpha characters (abbreviations, etc.)


### PR DESCRIPTION
Closes https://github.com/1612elphi/delphitools/issues/31 

This PR introduce a new WiFi QR code generation option, allowing users to create QR codes for WiFi networks, including the ability to specify a hidden SSID

- Add WiFi form to include security type options and adjust input types accordingly.
- Resolve lint errors by changing a variable to a constant in the dictionary module.

## PR Checklist
based on [[CONTRIBUTING.md](https://github.com/1612elphi/delphitools/blob/main/CONTRIBUTING.md)]

### Conventions
- [x] Read project structure, naming, and style conventions
- [x] PR references an open issue (open one first if it doesn't exist)

### Verification
- [x] `npm run build` succeeds with a fully static export and no server dependencies
- [x] `npm run lint` passes with no errors 
- [x] Changes tested manually in the browser
- [x] PR description references the issue it addresses

### Code style
- [x] User-facing text uses British spelling — colour, optimiser, favourite, etc.
- [x] Tool IDs and file names use `kebab-case`; component names use `PascalCase`
- [x] Uses existing `components/ui/` primitives (shadcn/ui) — no custom UI components
- [x] Styled with Tailwind CSS only — no custom CSS files
- [x] No unnecessary dependencies added — solved without a library where possible

## Screenshots & Logs:
### Build
```powershell

@movoid12 ➜ /workspaces/delphitools (feat/add-hidden-ssid-option) $ npm run build

> delphitools@0.1.0 build
> next build

▲ Next.js 16.2.9 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 32.9s
✓ Finished TypeScript in 18.5s    
✓ Collecting page data using 1 worker in 791ms    
✓ Generating static pages using 1 worker (56/56) in 3.0s
✓ Finalizing page optimization in 1044ms    

Route (app)
┌ ○ /
├ ○ /_not-found
└ ● /tools/[toolId]
  ├ /tools/matte-generator
  ├ /tools/scroll-generator
  ├ /tools/social-cropper
  └ [+49 more paths]


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)

```

#### Screenshot 1 / Click on WiFi QR tab with empty input fields
<img width="1511" height="864" alt="image" src="https://github.com/user-attachments/assets/4da24897-54dd-4125-b126-eaf4f192bab5" />

#### Screenshot 2 / With Network entries
<img width="1409" height="860" alt="image" src="https://github.com/user-attachments/assets/1b64e6a0-f441-4fe6-8363-f465c40903f0" />
