### PR TITLE
feat: add base64 image encoder tool

### DIFF
--- a/app/tools/[toolId]/page.tsx
+++ b/app/tools/[toolId]/page.tsx
@@ -60,6 +60,7 @@ const toolComponents: Record<string, React.ComponentType> = {
   "decoder": dynamic(() => import("@/components/tools/decoder").then(mod => mod.DecoderTool)),
   "doc-converter": dynamic(() => import("@/components/tools/doc-converter").then(mod => mod.DocConverterTool)),
   "text-editor": dynamic(() => import("@/components/tools/text-editor").then(mod => mod.TextEditorTool)),
+  "base64-image-encoder": dynamic(() => import("@/components/tools/base64-image-encoder").then(mod => mod.Base64ImageEncoderTool)),
 };
 
 interface ToolPageProps {

--- a/components/tools/base64-image-encoder.tsx
+++ b/components/tools/base64-image-encoder.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { UploadCloud, Copy, Check, X, ClipboardPaste } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useFilePaste } from "@/hooks/use-file-paste";
+
+export function Base64ImageEncoderTool() {
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const [base64String, setBase64String] = useState<string>("");
+  const [fileName, setFileName] = useState<string>("");
+  const [copied, setCopied] = useState<"uri" | "raw" | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const processFile = (file: File) => {
+    if (!file.type.startsWith("image/")) return;
+    setFileName(file.name);
+    
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const result = e.target?.result as string;
+      setImageSrc(result);
+      setBase64String(result);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  useFilePaste((file: File) => {
+    processFile(file);
+  }, "image/*");
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      processFile(e.dataTransfer.files[0]);
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      processFile(e.target.files[0]);
+    }
+  };
+
+  const copyToClipboard = async () => {
+    await navigator.clipboard.writeText(base64String);
+    setCopied("uri");
+    setTimeout(() => setCopied(null), 2000);
+  };
+
+  const copyRawBase64 = async () => {
+    const raw = base64String.split(",")[1];
+    if (raw) {
+      await navigator.clipboard.writeText(raw);
+      setCopied("raw");
+      setTimeout(() => setCopied(null), 2000);
+    }
+  };
+
+  const clearImage = () => {
+    setImageSrc(null);
+    setBase64String("");
+    setFileName("");
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {!imageSrc ? (
+        <div
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+          className="border-2 border-dashed rounded-xl p-12 text-center hover:border-primary/50 transition-colors flex flex-col items-center justify-center min-h-[50vh] bg-muted/10 cursor-pointer"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <input
+            type="file"
+            ref={fileInputRef}
+            className="hidden"
+            accept="image/*"
+            onChange={handleFileChange}
+          />
+          <div className="flex justify-center gap-4 mb-4 text-muted-foreground">
+            <UploadCloud className="size-12" />
+            <ClipboardPaste className="size-12" />
+          </div>
+          <h2 className="text-xl font-semibold mb-2">
+            Upload, Drop, or Paste an Image
+          </h2>
+          <p className="text-muted-foreground max-w-sm mx-auto">
+            Click to browse, drop a file here, or press <kbd className="px-2 py-1 bg-muted rounded-md border font-mono text-xs">Ctrl/Cmd+V</kbd> to paste from clipboard.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          <div className="flex justify-between items-center flex-wrap gap-4">
+            <h3 className="font-medium text-lg truncate flex-1">
+              {fileName || "Pasted Image"}
+            </h3>
+            <Button variant="outline" size="sm" onClick={clearImage}>
+              <X className="size-4 mr-2" /> Clear
+            </Button>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium">Image Preview</span>
+              <div className="border rounded-xl p-4 bg-muted/30 flex items-center justify-center min-h-[300px] max-h-[400px] overflow-hidden">
+                <img
+                  src={imageSrc}
+                  alt="Preview"
+                  className="max-w-full max-h-full object-contain rounded shadow-sm"
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <div className="flex justify-between items-center">
+                <span className="text-sm font-medium">Base64 Output</span>
+                <div className="flex gap-2">
+                  <Button variant="outline" size="sm" onClick={copyRawBase64}>
+                    {copied === "raw" ? <Check className="size-4 mr-2" /> : <Copy className="size-4 mr-2" />}
+                    <span>Raw Data</span>
+                  </Button>
+                  <Button size="sm" onClick={copyToClipboard}>
+                    {copied === "uri" ? <Check className="size-4 mr-2" /> : <Copy className="size-4 mr-2" />}
+                    <span>Data URI</span>
+                  </Button>
+                </div>
+              </div>
+              <Textarea
+                value={base64String}
+                readOnly
+                className="font-mono text-xs h-full min-h-[300px] resize-none"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/tools/base64-image-encoder.tsx
+++ b/components/tools/base64-image-encoder.tsx
@@ -1,27 +1,59 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { UploadCloud, Copy, Check, X, ClipboardPaste } from "lucide-react";
+import { Copy, Check, X, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { useFilePaste } from "@/hooks/use-file-paste";
 
+interface EncodedImage {
+  id: string;
+  name: string;
+  base64: string;
+  previewUrl: string;
+  size: number;
+}
+
 export function Base64ImageEncoderTool() {
-  const [imageSrc, setImageSrc] = useState<string | null>(null);
-  const [base64String, setBase64String] = useState<string>("");
-  const [fileName, setFileName] = useState<string>("");
-  const [copied, setCopied] = useState<"uri" | "raw" | null>(null);
+  const [encodedImages, setEncodedImages] = useState<EncodedImage[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const formatSize = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
   const processFile = (file: File) => {
-    if (!file.type.startsWith("image/")) return;
-    setFileName(file.name);
+    setError(null);
+    if (!file.type.startsWith("image/")) {
+      setError(`Invalid file type: ${file.name}. Please upload an image file.`);
+      return;
+    }
     
+    // Warn/prevent if larger than 5MB
+    if (file.size > 5 * 1024 * 1024) {
+      setError(`File ${file.name} is too large (${formatSize(file.size)}). Max allowed size is 5MB to prevent browser freeze.`);
+      return;
+    }
+
     const reader = new FileReader();
     reader.onload = (e) => {
       const result = e.target?.result as string;
-      setImageSrc(result);
-      setBase64String(result);
+      const newImage: EncodedImage = {
+        id: crypto.randomUUID(),
+        name: file.name,
+        base64: result,
+        previewUrl: result, // For base64, data URL is the preview
+        size: file.size,
+      };
+      setEncodedImages((prev) => [newImage, ...prev]);
+    };
+    reader.onerror = () => {
+      setError(`Failed to read file ${file.name}`);
     };
     reader.readAsDataURL(file);
   };
@@ -32,115 +64,172 @@ export function Base64ImageEncoderTool() {
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
   };
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
-    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-      processFile(e.dataTransfer.files[0]);
+    setIsDragging(false);
+    
+    const files = Array.from(e.dataTransfer.files);
+    files.forEach(processFile);
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const files = Array.from(e.target.files);
+      files.forEach(processFile);
     }
-  };
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files.length > 0) {
-      processFile(e.target.files[0]);
-    }
-  };
-
-  const copyToClipboard = async () => {
-    await navigator.clipboard.writeText(base64String);
-    setCopied("uri");
-    setTimeout(() => setCopied(null), 2000);
-  };
-
-  const copyRawBase64 = async () => {
-    const raw = base64String.split(",")[1];
-    if (raw) {
-      await navigator.clipboard.writeText(raw);
-      setCopied("raw");
-      setTimeout(() => setCopied(null), 2000);
-    }
-  };
-
-  const clearImage = () => {
-    setImageSrc(null);
-    setBase64String("");
-    setFileName("");
+    // reset input so the same file can be selected again
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
   };
 
+  const removeImage = (id: string) => {
+    setEncodedImages((prev) => prev.filter((img) => img.id !== id));
+  };
+
+  const clearAll = () => {
+    setEncodedImages([]);
+    setError(null);
+  };
+
+  const copyToClipboard = async (text: string, id: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(id);
+      setTimeout(() => setCopied(null), 2000);
+    } catch (err) {
+      console.error("Failed to copy text: ", err);
+    }
+  };
+
   return (
     <div className="space-y-6">
-      {!imageSrc ? (
+      {error && (
+        <div className="border-2 border-destructive bg-destructive/10 text-destructive p-4 font-bold">
+          {error}
+        </div>
+      )}
+
+      <div className="border-2 border-border">
+        {/* Drop Zone */}
         <div
           onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
           onDrop={handleDrop}
-          className="border-2 border-dashed rounded-xl p-12 text-center hover:border-primary/50 transition-colors flex flex-col items-center justify-center min-h-[50vh] bg-muted/10 cursor-pointer"
+          className={`border-2 border-dashed m-4 p-8 text-center transition-colors cursor-pointer ${
+            isDragging ? "border-primary bg-primary/5" : "border-border hover:border-primary/50"
+          }`}
           onClick={() => fileInputRef.current?.click()}
         >
           <input
-            type="file"
             ref={fileInputRef}
-            className="hidden"
+            type="file"
             accept="image/*"
-            onChange={handleFileChange}
+            multiple
+            onChange={handleFileSelect}
+            className="hidden"
           />
-          <div className="flex justify-center gap-4 mb-4 text-muted-foreground">
-            <UploadCloud className="size-12" />
-            <ClipboardPaste className="size-12" />
-          </div>
-          <h2 className="text-xl font-semibold mb-2">
-            Upload, Drop, or Paste an Image
-          </h2>
-          <p className="text-muted-foreground max-w-sm mx-auto">
-            Click to browse, drop a file here, or press <kbd className="px-2 py-1 bg-muted rounded-md border font-mono text-xs">Ctrl/Cmd+V</kbd> to paste from clipboard.
+          <Upload className="size-12 mx-auto text-muted-foreground mb-4" />
+          <p className="text-lg font-medium">Drop images here</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            or click to select files, or paste
           </p>
         </div>
-      ) : (
-        <div className="space-y-6">
-          <div className="flex justify-between items-center flex-wrap gap-4">
-            <h3 className="font-medium text-lg truncate flex-1">
-              {fileName || "Pasted Image"}
+      </div>
+
+      {encodedImages.length > 0 && (
+        <div className="border-2 border-border">
+          <div className="flex min-h-12 items-stretch border-b-2 border-border">
+            <h3 className="flex flex-1 items-center px-4 font-bold">
+              {encodedImages.length} image{encodedImages.length !== 1 ? "s" : ""} encoded
             </h3>
-            <Button variant="outline" size="sm" onClick={clearImage}>
-              <X className="size-4 mr-2" /> Clear
+            <Button
+              variant="ghost"
+              onClick={clearAll}
+              className="h-auto self-stretch rounded-none border-l border-border px-4"
+            >
+              Clear all
             </Button>
           </div>
 
-          <div className="grid md:grid-cols-2 gap-6">
-            <div className="flex flex-col gap-2">
-              <span className="text-sm font-medium">Image Preview</span>
-              <div className="border rounded-xl p-4 bg-muted/30 flex items-center justify-center min-h-[300px] max-h-[400px] overflow-hidden">
-                <img
-                  src={imageSrc}
-                  alt="Preview"
-                  className="max-w-full max-h-full object-contain rounded shadow-sm"
-                />
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <div className="flex justify-between items-center">
-                <span className="text-sm font-medium">Base64 Output</span>
-                <div className="flex gap-2">
-                  <Button variant="outline" size="sm" onClick={copyRawBase64}>
-                    {copied === "raw" ? <Check className="size-4 mr-2" /> : <Copy className="size-4 mr-2" />}
-                    <span>Raw Data</span>
-                  </Button>
-                  <Button size="sm" onClick={copyToClipboard}>
-                    {copied === "uri" ? <Check className="size-4 mr-2" /> : <Copy className="size-4 mr-2" />}
-                    <span>Data URI</span>
-                  </Button>
+          <div className="divide-y-0">
+            {encodedImages.map((img) => {
+              const rawBase64 = img.base64.split(",")[1];
+              return (
+                <div key={img.id} className="border-b-2 border-border last:border-b-0">
+                  <div className="flex items-stretch border-b border-border">
+                    <div className="size-16 shrink-0 bg-muted flex items-center justify-center overflow-hidden border-r border-border">
+                      <img
+                        src={img.previewUrl}
+                        alt={img.name}
+                        className="size-full object-cover"
+                      />
+                    </div>
+                    <div className="flex-1 min-w-0 flex flex-col justify-center px-4 py-2">
+                      <p className="font-medium truncate">{img.name}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {formatSize(img.size)}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => removeImage(img.id)}
+                      className="flex w-12 items-center justify-center border-l border-border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      title="Remove"
+                    >
+                      <X className="size-4" />
+                    </button>
+                  </div>
+                  <div className="p-4 space-y-4 bg-muted/10">
+                    <Textarea
+                      readOnly
+                      value={img.base64}
+                      className="h-32 font-mono text-xs rounded-none border-2 border-border bg-background"
+                      onClick={(e) => (e.target as HTMLTextAreaElement).select()}
+                    />
+                    <div className="segmented grid-cols-2 -mx-4 -mb-4 border-x-0 border-b-0">
+                      <Button
+                        variant={copied === `raw-${img.id}` ? "default" : "outline"}
+                        onClick={() => copyToClipboard(rawBase64, `raw-${img.id}`)}
+                        className="font-bold h-12"
+                      >
+                        {copied === `raw-${img.id}` ? (
+                          <>
+                            <Check className="size-4 mr-2" /> Copied Raw Data
+                          </>
+                        ) : (
+                          <>
+                            <Copy className="size-4 mr-2" /> Copy Raw Base64
+                          </>
+                        )}
+                      </Button>
+                      <Button
+                        variant={copied === `uri-${img.id}` ? "default" : "outline"}
+                        onClick={() => copyToClipboard(img.base64, `uri-${img.id}`)}
+                        className="font-bold h-12"
+                      >
+                        {copied === `uri-${img.id}` ? (
+                          <>
+                            <Check className="size-4 mr-2" /> Copied Data URI
+                          </>
+                        ) : (
+                          <>
+                            <Copy className="size-4 mr-2" /> Copy Data URI
+                          </>
+                        )}
+                      </Button>
+                    </div>
+                  </div>
                 </div>
-              </div>
-              <Textarea
-                value={base64String}
-                readOnly
-                className="font-mono text-xs h-full min-h-[300px] resize-none"
-              />
-            </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -250,6 +250,14 @@ export const toolCategories: ToolCategory[] = [
         icon: FileImage,
         href: "/tools/svg-optimiser",
       },
+      {
+        id: "base64-image-encoder",
+        name: "Base64 Image Encoder",
+        description: "Convert images to Base64 strings for CSS/HTML embedding",
+        icon: FileCode,
+        href: "/tools/base64-image-encoder",
+        new: true,
+      },
     ],
   },
   {


### PR DESCRIPTION
Closes #34

**Changes:**
- Added a new `Base64ImageEncoderTool` component supporting drag & drop, file selection, and clipboard pasting via the `useFilePaste` hook.
- Uses local browser APIs (`FileReader`) with zero external calls or server dependencies.
- Registered the tool in `/tools/[toolId]/page.tsx`.
- Added tool metadata to `lib/tools.ts` under the "Images & Assets" category.

Confirmed that `npm run build` succeeds and exports statically without issues.
