### PR TITLE
feat: add text case converter tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Long live the handmade web.
 - typo calc (agates, ciceros, picas, pt, inches, mm)
 - paper sizes
 - word counter
+- text case converter
 - text diff
 - glyph browser
 - font file explorer

--- a/app/tools/[toolId]/page.tsx
+++ b/app/tools/[toolId]/page.tsx
@@ -56,6 +56,7 @@ const toolComponents: Record<string, React.ComponentType> = {
   "image-clipper": dynamic(() => import("@/components/tools/image-clipper").then(mod => mod.ImageClipperTool)),
   "pixel-picker": dynamic(() => import("@/components/tools/pixel-picker").then(mod => mod.PixelPickerTool)),
   "palette-extractor": dynamic(() => import("@/components/tools/palette-extractor").then(mod => mod.PaletteExtractorTool)),
+  "text-case-converter": dynamic(() => import("@/components/tools/text-case-converter").then(mod => mod.TextCaseConverterTool)),
   "text-diff": dynamic(() => import("@/components/tools/text-diff").then(mod => mod.TextDiffTool)),
   "decoder": dynamic(() => import("@/components/tools/decoder").then(mod => mod.DecoderTool)),
   "doc-converter": dynamic(() => import("@/components/tools/doc-converter").then(mod => mod.DocConverterTool)),

--- a/components/tools/text-case-converter.tsx
+++ b/components/tools/text-case-converter.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Check, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+function sentenceCase(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/(^\s*\w|[.!?]+\s*\w)/g, (c) => c.toUpperCase());
+}
+
+function capitalizedCase(str: string): string {
+  return str.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function alternatingCase(str: string): string {
+  return [...str]
+    .map((c, i) => (i % 2 === 0 ? c.toLowerCase() : c.toUpperCase()))
+    .join("");
+}
+
+function inverseCase(str: string): string {
+  return [...str]
+    .map((c) => (c === c.toUpperCase() ? c.toLowerCase() : c.toUpperCase()))
+    .join("");
+}
+
+export function TextCaseConverterTool() {
+  const [text, setText] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const cases: { label: string; transform: (s: string) => string }[] = [
+    { label: "Sentence case", transform: sentenceCase },
+    { label: "lower case", transform: (s) => s.toLowerCase() },
+    { label: "UPPER CASE", transform: (s) => s.toUpperCase() },
+    { label: "Capitalized Case", transform: capitalizedCase },
+    { label: "aLtErNaTiNg cAsE", transform: alternatingCase },
+    { label: "InVeRsE CaSe", transform: inverseCase },
+  ];
+
+  const copyText = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="border-2 border-border">
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Start typing or paste your text here..."
+        className="w-full min-h-[300px] p-4 bg-background text-base resize-y focus:outline-none border-0"
+      />
+
+      <div className="flex flex-wrap items-stretch border-t border-border">
+        {cases.map(({ label, transform }, i) => (
+          <Button
+            key={label}
+            variant="outline"
+            onClick={() => setText(transform(text))}
+            disabled={!text}
+            className={`h-14 flex-1 border-0 text-base ${i < cases.length - 1 ? "border-r border-border" : ""}`}
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="flex items-stretch border-t border-border">
+        <Button
+          variant="outline"
+          onClick={() => setText("")}
+          disabled={!text}
+          className="h-14 flex-1 border-0 border-r border-border text-base"
+        >
+          <Trash2 className="size-4 mr-2" />
+          Clear
+        </Button>
+        <Button
+          variant="outline"
+          onClick={copyText}
+          disabled={!text}
+          className="h-14 flex-1 border-0 text-base"
+        >
+          {copied ? (
+            <>
+              <Check className="size-4 mr-2" /> Copied!
+            </>
+          ) : (
+            <>
+              <Copy className="size-4 mr-2" /> Copy
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -46,6 +46,7 @@ import {
   Wind,
   GitCompare,
   KeyRound,
+  CaseSensitive,
 } from "lucide-react";
 
 export interface Tool {
@@ -314,6 +315,14 @@ export const toolCategories: ToolCategory[] = [
         description: "Convert pixels to rem units",
         icon: Ruler,
         href: "/tools/px-to-rem",
+      },
+      {
+        id: "text-case-converter",
+        name: "Text Case Converter",
+        description: "Convert text between sentence, lower, upper, capitalized, alternating, and inverse case",
+        icon: CaseSensitive,
+        href: "/tools/text-case-converter",
+        new: true,
       },
       {
         id: "text-diff",


### PR DESCRIPTION
Adds a Text Case Converter tool under Typography & Text for converting text between different cases with a single click

What's in these changes
- Single textarea - paste or type, then tap a case button to transform in-place
- Six case transformations: Sentence case, lower case, UPPER CASE, Capitalized Case, aLtErNaTiNg cAsE, InVeRsE CaSe
- Clear + Copy buttons with brief "Copied!" feedback
- All transformations are pure functions ~20 lines total.
- Marked as new
- Tool addition to the README

Screenshots:
<img width="2490" height="1660" alt="Screenshot 2026-07-03 at 11-23-36 Text Case Converter - delphitools" src="https://github.com/user-attachments/assets/697b6745-6dbd-442e-919c-aa662bef6c35" />
<img width="2490" height="1660" alt="Screenshot 2026-07-03 at 11-23-48 Text Case Converter - delphitools" src="https://github.com/user-attachments/assets/64b5fbe3-3276-42e5-9ca8-a9d0c49dcc0a" />