### PR TITLE
Fix SVG Optimiser tool by disabling bugged removeDimensions option

### DIFF
--- a/components/tools/svg-optimiser.tsx
+++ b/components/tools/svg-optimiser.tsx
@@ -77,7 +77,6 @@ export function SvgOptimiserTool() {
         multipass: true,
         plugins: [
           "preset-default",
-          "removeDimensions",
           {
             name: "removeAttrs",
             params: {


### PR DESCRIPTION
This option can change the dimensions of elements inside the SVG, changing how the SVG looks. This option should stay removed until the bug in SVGO is fixed, at which point it can be returned.

Issue in SVGO for reference: https://github.com/svg/svgo/issues/2217

Fixes #46