### PR TITLE
Implement zip download for favicon genny (again)

### DIFF
--- a/app/components/tools/favicon-genny.gts
+++ b/app/components/tools/favicon-genny.gts
@@ -168,15 +168,27 @@ export default class FaviconGennyTool extends Component {
 		);
 	};
 
-	downloadAll = () => {
-		this.favicons.forEach((favicon, i) => {
-			this.#timers.push(
-				setTimeout(
-					() => this.download(favicon),
-					i * DOWNLOAD_GAP_MS,
-				),
-			);
-		});
+	downloadAll = async () => {
+		try {
+			const JSZip = (await import('jszip')).default;
+			const zip = new JSZip();
+			this.favicons.forEach((favicon) => {
+				const bytes = dataUrlToBytes(favicon.dataUrl);
+				zip.file(`favicon-${favicon.size}x${favicon.size}.png`, bytes);
+			});
+			const blob = await zip.generateAsync({ type: 'blob' });
+			downloadBlob(blob, 'favicons.zip');
+		} catch (error) {
+			console.error('Error downloading favicons zip, using fallback', error);
+			this.favicons.forEach((favicon, i) => {
+				this.#timers.push(
+					setTimeout(
+						() => this.download(favicon),
+						i * DOWNLOAD_GAP_MS,
+					),
+				);
+			});
+		}
 	};
 
 	downloadIco = () => {


### PR DESCRIPTION
(Issue https://github.com/1612elphi/delphitools/issues/44, same as before)

Replace the sequential individual file downloads in `downloadAll` with a single ZIP archive generation using `jszip` so we don't flash the user with a download dialog spam.

If the ZIP generation fails, the method gracefully falls back to the previous behavior of downloading files individually with a delay.

`npm run build` builds fine
`npm run lint` has no more errors than there already were, and anyways not in the file I edited.

Keep being awesome!