### PR TITLE
fix(screen-recorder): fix Firefox stall/feedback and Chrome audio filtering/mixing

### DIFF
--- a/app/components/tools/screen-recorder.gts
+++ b/app/components/tools/screen-recorder.gts
@@ -19,11 +19,17 @@ const MIC_DENIED =
 const UNSUPPORTED = 'Screen recording is not supported in this browser.';
 
 const MIC_LABEL = 'Mix in microphone audio';
+const ECHO_LABEL = 'Echo cancellation';
+const NOISE_LABEL = 'Noise suppression';
+const GAIN_LABEL = 'Auto gain control';
 
 export default class ScreenRecorderTool extends Component {
 	@tracked status: 'idle' | 'recording' | 'paused' | 'finished' = 'idle';
 	@tracked elapsedMs = 0;
 	@tracked micMixIn = false;
+	@tracked echoCancellation = false;
+	@tracked noiseSuppression = false;
+	@tracked autoGainControl = false;
 	@tracked videoBlob: Blob | null = null;
 	@tracked videoUrl: string | null = null;
 	@tracked duration = 0;
@@ -36,6 +42,7 @@ export default class ScreenRecorderTool extends Component {
 	#displayStream: MediaStream | null = null;
 	#micStream: MediaStream | null = null;
 	#combinedStream: MediaStream | null = null;
+	#audioCtx: AudioContext | null = null;
 	#chunks: Blob[] = [];
 	#startedAt = 0;
 	#pausedAt = 0;
@@ -68,17 +75,38 @@ export default class ScreenRecorderTool extends Component {
 
 	start = async () => {
 		this.error = '';
-		if (!navigator.mediaDevices?.getDisplayMedia) {
+		if (
+			!navigator.mediaDevices?.getDisplayMedia ||
+			typeof MediaRecorder === 'undefined'
+		) {
 			this.error = UNSUPPORTED;
 			return;
 		}
 
 		try {
-			this.#displayStream =
-				await navigator.mediaDevices.getDisplayMedia({
-					video: true,
-					audio: true,
-				});
+			try {
+				this.#displayStream =
+					await navigator.mediaDevices.getDisplayMedia(
+						{
+							video: true,
+							audio: {
+								echoCancellation: false,
+								noiseSuppression: false,
+								autoGainControl: false,
+								sampleRate: 48000,
+								channelCount: 2,
+							},
+						},
+					);
+			} catch {
+				this.#displayStream =
+					await navigator.mediaDevices.getDisplayMedia(
+						{
+							video: true,
+							audio: true,
+						},
+					);
+			}
 		} catch (err) {
 			const name = (err as Error)?.name;
 			// cancel throws NotAllowedError
@@ -93,39 +121,112 @@ export default class ScreenRecorderTool extends Component {
 
 		if (!this.#displayStream) return;
 
-		const tracks = [...this.#displayStream.getTracks()];
 		this.#micStream = null;
 
 		if (this.micMixIn) {
+			// request mic with user filters, falling back to basic audio on failure
 			try {
 				this.#micStream =
 					await navigator.mediaDevices.getUserMedia(
 						{
-							audio: true,
+							audio: {
+								echoCancellation:
+									{
+										ideal: this
+											.echoCancellation,
+									},
+								noiseSuppression:
+									{
+										ideal: this
+											.noiseSuppression,
+									},
+								autoGainControl:
+									{
+										ideal: this
+											.autoGainControl,
+									},
+							},
 						},
 					);
-				tracks.push(
-					...this.#micStream.getAudioTracks(),
-				);
 			} catch {
-				this.error = MIC_DENIED;
+				try {
+					this.#micStream =
+						await navigator.mediaDevices.getUserMedia(
+							{ audio: true },
+						);
+				} catch {
+					this.error = MIC_DENIED;
+				}
 			}
 		}
 
-		this.#combinedStream = new MediaStream(tracks);
+		const displayAudio = this.#displayStream.getAudioTracks();
+		const micAudio = this.#micStream?.getAudioTracks() ?? [];
+		const audioTracks = [...displayAudio, ...micAudio];
+		const videoTrack = this.#displayStream.getVideoTracks()[0];
+		const finalTracks: MediaStreamTrack[] = [];
+		if (videoTrack) finalTracks.push(videoTrack);
 
-		const candidates = [
-			'video/webm;codecs=vp9,opus',
-			'video/webm;codecs=vp8,opus',
-			'video/webm',
-		];
+		// Always normalize audio through AudioContext @ 48kHz to avoid Opus
+		// clock drift: tab/system audio is often 44.1kHz while Opus expects 48kHz.
+		// Raw track → slow/pitch-down playback. For >1 tracks this also mixes.
+		if (audioTracks.length >= 1) {
+			try {
+				const ctx = new AudioContext({
+					sampleRate: 48000,
+				});
+				this.#audioCtx = ctx;
+				if (ctx.state === 'suspended')
+					await ctx.resume();
+				const dest = ctx.createMediaStreamDestination();
+				for (const t of audioTracks) {
+					const src = ctx.createMediaStreamSource(
+						new MediaStream([t]),
+					);
+					src.connect(dest);
+				}
+				const mixed = dest.stream.getAudioTracks()[0];
+				if (mixed) finalTracks.push(mixed);
+				else {
+					for (const t of audioTracks)
+						if (t) finalTracks.push(t);
+				}
+			} catch {
+				for (const t of audioTracks)
+					if (t) finalTracks.push(t);
+			}
+		}
+
+		this.#combinedStream = new MediaStream(finalTracks);
+
+		// omit opus codec when no audio tracks exist to prevent recorder onstop hangs
+		const hasAudio = finalTracks.some((t) => t.kind === 'audio');
+		const candidates = hasAudio
+			? [
+					'video/webm;codecs=vp9,opus',
+					'video/webm;codecs=vp8,opus',
+					'video/webm',
+				]
+			: [
+					'video/webm;codecs=vp9',
+					'video/webm;codecs=vp8',
+					'video/webm',
+				];
 		const mimeType =
-			candidates.find((t) =>
-				MediaRecorder.isTypeSupported(t),
-			) ?? '';
+			candidates.find((t) => {
+				try {
+					return MediaRecorder.isTypeSupported(t);
+				} catch {
+					return false;
+				}
+			}) ?? '';
+		const recorderOpts: MediaRecorderOptions = {};
+		if (mimeType) recorderOpts.mimeType = mimeType;
+		if (hasAudio) recorderOpts.audioBitsPerSecond = 128000;
+		recorderOpts.videoBitsPerSecond = 2500000;
 		this.#recorder = new MediaRecorder(
 			this.#combinedStream,
-			mimeType ? { mimeType } : undefined,
+			recorderOpts,
 		);
 		this.#chunks = [];
 		this.#recorder.ondataavailable = (event) => {
@@ -153,7 +254,7 @@ export default class ScreenRecorderTool extends Component {
 		this.elapsedMs = 0;
 		this.#startedAt = performance.now();
 		this.status = 'recording';
-		this.#recorder.start(100);
+		this.#recorder.start();
 		this.#rafId = requestAnimationFrame(this.#tickElapsed);
 	};
 
@@ -165,6 +266,8 @@ export default class ScreenRecorderTool extends Component {
 		this.#displayStream = null;
 		this.#micStream = null;
 		this.#combinedStream = null;
+		void this.#audioCtx?.close().catch(() => {});
+		this.#audioCtx = null;
 		cancelAnimationFrame(this.#rafId);
 
 		if (this.#chunks.length === 0) {
@@ -187,6 +290,8 @@ export default class ScreenRecorderTool extends Component {
 	}
 
 	#stopRecording() {
+		void this.#audioCtx?.close().catch(() => {});
+		this.#audioCtx = null;
 		const recorder = this.#recorder;
 		if (recorder) {
 			// prevent resurrecting discarded takes
@@ -212,8 +317,9 @@ export default class ScreenRecorderTool extends Component {
 	}
 
 	#releaseTake() {
-		if (this.videoUrl) URL.revokeObjectURL(this.videoUrl);
+		const url = this.videoUrl;
 		this.videoUrl = null;
+		if (url) setTimeout(() => URL.revokeObjectURL(url), 500);
 		this.videoBlob = null;
 		this.duration = 0;
 		this.width = 0;
@@ -237,8 +343,42 @@ export default class ScreenRecorderTool extends Component {
 		else if (this.status === 'paused') this.#recorder?.resume();
 	};
 
+	// dynamically update filters on active mic tracks
+	#applyMicConstraints() {
+		for (const track of this.#micStream?.getAudioTracks() ?? []) {
+			void track
+				.applyConstraints({
+					echoCancellation: {
+						ideal: this.echoCancellation,
+					},
+					noiseSuppression: {
+						ideal: this.noiseSuppression,
+					},
+					autoGainControl: {
+						ideal: this.autoGainControl,
+					},
+				})
+				.catch(() => {});
+		}
+	}
+
 	setMicMixIn = (value: boolean) => {
 		this.micMixIn = value;
+	};
+
+	setEchoCancellation = (value: boolean) => {
+		this.echoCancellation = value;
+		this.#applyMicConstraints();
+	};
+
+	setNoiseSuppression = (value: boolean) => {
+		this.noiseSuppression = value;
+		this.#applyMicConstraints();
+	};
+
+	setAutoGainControl = (value: boolean) => {
+		this.autoGainControl = value;
+		this.#applyMicConstraints();
 	};
 
 	clear = () => {
@@ -268,8 +408,14 @@ export default class ScreenRecorderTool extends Component {
 	};
 
 	registerLive = modifier((video: HTMLVideoElement) => {
-		if (this.#combinedStream) {
-			video.srcObject = this.#combinedStream;
+		const vTrack =
+			this.#displayStream?.getVideoTracks()[0] ??
+			this.#combinedStream?.getVideoTracks()[0];
+		if (vTrack) {
+			video.srcObject = new MediaStream([vTrack]);
+			video.muted = true;
+			// Firefox can ignore muted attribute on MediaStream with audio
+			video.volume = 0;
 			void video.play();
 		}
 		return () => {
@@ -286,7 +432,7 @@ export default class ScreenRecorderTool extends Component {
 		return () => {
 			if (this.#video === video) this.#video = null;
 			video.pause();
-			video.src = '';
+			video.removeAttribute('src');
 			video.load();
 		};
 	});
@@ -437,6 +583,34 @@ export default class ScreenRecorderTool extends Component {
 						/>
 					</label>
 				</div>
+				{{#if this.micMixIn}}
+					<div class="dt-sr-fields">
+						<label class="dt-sr-field">
+							<span>Echo cancellation</span>
+							<Switch
+								@checked={{this.echoCancellation}}
+								@onChange={{this.setEchoCancellation}}
+								@label={{ECHO_LABEL}}
+							/>
+						</label>
+						<label class="dt-sr-field">
+							<span>Noise suppression</span>
+							<Switch
+								@checked={{this.noiseSuppression}}
+								@onChange={{this.setNoiseSuppression}}
+								@label={{NOISE_LABEL}}
+							/>
+						</label>
+						<label class="dt-sr-field">
+							<span>Auto gain</span>
+							<Switch
+								@checked={{this.autoGainControl}}
+								@onChange={{this.setAutoGainControl}}
+								@label={{GAIN_LABEL}}
+							/>
+						</label>
+					</div>
+				{{/if}}
 
 				<div class="dt-sr-surface">
 					{{#if (eq this.status "idle")}}

--- a/app/lib/tools.ts
+++ b/app/lib/tools.ts
@@ -412,7 +412,7 @@ export const toolCategories: ToolCategory[] = [
 				id: 'screen-recorder',
 				name: 'Screen Recorder',
 				description:
-					'Record your screen with optional microphone audio',
+					'Record your screen with optional tab audio (supported browsers only) and microphone audio',
 				icon: 'monitor-up',
 				href: '/tools/screen-recorder',
 				new: true,


### PR DESCRIPTION
- **Add MIT License to the project**
- **added palette genny**
- **improved qr. added new tools.**
- **lang changes**
- **acknowledgements added**
- **Update ACKNOWLEDGEMENTS.md**
- **Update markdown-writer.tsx**
- **added vercel analytics**
- **Add Vercel Speed Insights to Next.js**
- **added background remover**
- **Update background-remover.tsx**
- **Update ACKNOWLEDGEMENTS.md**
- **fixes**
- **minor changes**
- **Reduce Vercel edge requests for free tier**
- **Add Zine Imposer tool**
- **Disable link prefetching for Cloudflare Pages**
- **Update svg-optimiser.tsx**
- **Update palette export branding to tools.rmv.fyi**
- **palette changes**
- **Update palette-collection.ts**
- **added palette generator**
- **les go**
- **refactor: extract paper size data and add fraction formatting utilities**
- **feat: add global mm/in unit toggle with localStorage persistence**
- **feat: add smart search with name filtering and dimension matching**
- **feat: add closest matches banner for dimension searches**
- **feat: add image upload with DPI selector for finding closest paper sizes**
- **Fix memory leak and error handling in handleFileUpload**
- **feat: add PDF upload support using pdf-lib**
- **fix: add error handling for PDF parsing in paper-sizes tool**
- **feat: polish paper size tool with orientation handling and edge cases**
- **new tools added**
- **fix: extract OptionSlider to top-level component to fix slider jank**
- **feat: redesign image tracer controls panel**
- **feat: add X button on file info card to clear active image**
- **fix: prevent preview from cropping large images and SVGs**
- **fix: constrain SVG preview to container bounds**
- **fix: make SVG preview responsive and presets horizontally scrollable**
- **feat: replace preset scroll strip with popover combobox**
- **feat: use 4x4 icon grid in preset popover, drop descriptions**
- **perf: render traced SVG as <img> blob URL and trace in Web Worker**
- **feat: overlay settings panel when a preset is active**
- **feat: sticky preview pane with actions toolbar underneath**
- **feat: restructure layout with preview on top and controls underneath**
- **feat: move preset and retrace above controls, output size into toolbar**
- **feat: add Preset label to selector and make Retrace fill remaining width**
- **fix: remove package-lock.json so Cloudflare uses bun**
- **Update image-tracer.tsx**
- **Update image-tracer.tsx**
- **feat(image-converter): add gifenc and utif dependencies**
- **feat(image-converter): types, encoders, and conversion pipeline**
- **feat(image-converter): complete UI with format options, resize, and ZIP download**
- **feat(image-converter): type declarations, metadata update, and build fix**
- **fix(image-converter): address code review findings**
- **design(image-converter): redesign with technical instrument aesthetic**
- **style(image-converter): redesign settings and resize panels**
- **feat(image-converter): add ICNS (Apple Icon) format support**
- **Update .gitignore**
- **feat(colour): replace NTC.js with meodai/color-names library**
- **Added Cassini**
- **Update page.tsx**
- **feat(guillotine-director): register tool and create Print & Production category**
- **feat(pdf-preflight): add pdfjs-dist dependency**
- **feat(pdf-preflight): register tool with stub component**
- **feat(guillotine-director): add imposition math, input phase UI, and SVG preview**
- **feat(pdf-preflight): build file upload drop zone with PDF validation**
- **feat(guillotine-director): build guided cutting phase with step-by-step UI**
- **feat(guillotine-director): add unit labels to input fields**
- **feat(pdf-preflight): add full analysis, rendering, and report UI**
- **fix(guillotine-director): register in page-level dynamic imports**
- **fix(pdf-preflight): address spec review findings**
- **feat(guillotine-director): rename card→product, add sheet presets, fix cut direction, polish UI**
- **fix(pdf-preflight): address code quality review findings**
- **feat(guillotine-director): add measure diagrams and "expect around" hint**
- **fix(pdf-preflight): use local pdf.js worker instead of CDN**
- **feat(pdf-preflight): show current page issues under preview**
- **feat(pdf-preflight): add download button for embedded fonts**
- **feat(guillotine-director): use long side/short side language in measure steps**
- **fix(guillotine-director): ensure waste always falls toward operator**
- **fix(guillotine-director): add short edge/long edge terminology to all cut instructions**
- **Add Taxiway card to Friends of Delphi section**
- **Add Taxiway CTA to PDF preflight tool, update links to rmv.fyi**
- **Move PDF Preflight to Print & Production category**
- **Add Shavian transliterator design spec**
- **Update Shavian transliterator spec after review**
- **Add Shavian transliterator implementation plan**
- **feat(shavian): add ARPABET/IPA/Shavian phoneme mapping module**
- **feat(shavian): add per-letter alternative phoneme generation**
- **feat(shavian): add rule-based grapheme-to-phoneme heuristic engine**
- **feat(shavian): add transliteration pipeline with tokeniser and dictionary lookup**
- **feat(shavian): add dictionary build script and generate core/full dictionaries**
- **feat(shavian): bundle Noto Sans Shavian web font**
- **feat(shavian): register Shavian Transliterator in new Turbo-nerd Shit category**
- **feat(shavian): add Shavian Transliterator tool component with gloss grid and PNG export**
- **feat(shavian): make namer dot a manual toggle by clicking the Latin word**
- **feat(shavian): add Shavian alphabet explanation and default sample text**
- **fix(shavian): fix namer dot toggle, move dot to Shavian row, tighten punctuation spacing**
- **fix(shavian): merge Y+UW into yew (𐑿) ligature**
- **Switch to static export to eliminate Worker invocations**
- **feat(imposer): register imposer tool in catalogue**
- **feat(imposition): add pure-TS imposition layout engine (lib/imposition.ts)**
- **feat(imposer): build ImposerTool component for print imposition**
- **fix(imposer): register in dynamic import page and rename to Print Imposer**
- **docs: add imposer preview redesign spec**
- **feat(imposer): redesign control panel and add preview/duplex features**
- **feat(imposer): add searchable paper size combobox, blank page stepper, and sheet nav buttons**
- **feat(shavian): cycle word markers between namer dot, acroring, and acroarc**
- **fix(shavian): show heuristic words in red text instead of dashed underline**
- **fix(shavian): show heuristic IPA in red instead of Shavian text**
- **feat(shavian): add shorthands for the, of, and, to, for**
- **feat(shavian): add ARPABET overrides for PALM vowel and THOUGHT bugs**
- **fix(shavian): map unstressed IY0 to 𐑦 (kit) not 𐑰 (fleece)**
- **rebrand from "handmade" to "indie" — new hero image and sidebar text**
- **fine. add dark mode. are you happy now.**
- **fix(scroll-generator): download all slides, not just the first (#12)**
- **fix(graph-calc): prevent page scroll when zooming the graph (#13)**
- **docs: update readme with full tool list**
- **feat(paste-image): add Paste Image tool for clipboard image pasting and editing**
- **fix(tools): update href for Paste Image tool to correct path**
- **fix(gradient-genny): normalize hex values to prevent double-# crash**
- **fix(gradient-genny): defer hex input updates to Enter/blur to prevent invalid colour crashes**
- **fix(gradient-genny): remap positions to list order when reordering colour stops**
- **feat(gradient-genny): re-sort stops by position on Enter/blur so out-of-order values animate into place**
- **finish: simplify useDeferredInput hook and harden normalizeHex validation**
- **docs: add CONTRIBUTING.md with project philosophy and guidelines**
- **feat: add search bar**
- **finish: swap Geist Mono for IBM Plex Mono, add donation links**
- **refactor(paste-image): improve state management and cleanup for object URLs. Add comments to explain code better**
- **Fix typo in 'Paste Image' description**
- **fix(paste-image): simplify UI, fix stale closure bug, use theme tokens**
- **feat(paste-image): add contributor attribution for @himanshubalani**
- **feat(colour): add global colour notation selector with 9 formats**
- **feat(images): add Image Clipper tool to trim transparent PNG edges**
- **fix(image-clipper): register in dynamic tool page component map**
- **chore: remove unused tool component registry**
- **feat: add iOS app hero card with TestFlight beta link**
- **chore: fix typo**
- **copy: iOS card tagline now mentions iPad**
- **fix: improve accessibility and resolve memory leaks**
- **fix: address review feedback - trig loop, dispose, aria-labels**
- **fix(sci-calc): handle deg mode via mathjs scope override**
- **fix(a11y): restore accessible names on external links**
- **feat: add contributors section to about panels**
- **fix(a11y): collapse duplicate About dialog triggers into one button**
- **fix(svg-optimiser): render preview via blob URL img instead of inlined HTML**
- **fix(graph-calc): compile via mathjs instead of new Function() on user input**
- **fix: guard async setState against unmount in three tools**
- **feat(a11y): add skip-link and wrap sidebar nav (#25)**
- **fix(a11y): restore sidebar flex layout and credit contributor**
- **feat: add Pixel Picker and Palette Extractor tools**
- **chore: sort tools alphabetically within each category**
- **chore: move Greatest Hits above iOS promo section**
- **chore: remove Guillotine Director tool**
- **feat: add clipboard paste support to all file drop zones**
- **feat: add Text Diff tool**
- **feat: update iOS card for App Store launch**
- **added statement on AI usage in the project**
- **feat: add Cipher Decoder tool**
- **feat: overhaul matte generator UI with rotation and custom sizes**
- **refactor: migrate native selects to shadcn Select across tools**
- **fix: guard canvas getContext nulls in pixel-picker**
- **feat: overhaul scroll generator UI**
- **feat: overhaul social cropper UI with live auto-cropping**
- **feat: overhaul watermarker UI**
- **feat(build): add docker support with the current bun runtime  (#29)**
- **feat: replace iOS card with combined download card**
- **feat(zine-imposer): add accordion fold, fold-template engine, UI redesign**
- **feat(zine-imposer: add 2-up printing to concertina mode**
- **docs(parity): note accordion split (two-up) sub-option**
- **feat(sidebar): show build commit SHA on brand hover**
- **build(docker): stamp version label via COMMIT_SHA build arg**
- **feat(about): add "With thanks to" donor credits section**
- **feat(about): add Kacper Węgrowski (Wikipedia) to donor credits**
- **chore(quality): raise react-doctor score from 77 to 100**
- **feat(tools): add Document Converter (#11) and distraction-free Text Editor**
- **feat(home): Pride mark + peelable sticker wall**
- **docs(readme): sync tool list to the current registry**
- **feat(editor): GFM support — strikethrough, task lists, footnotes, tables**
- **feat(editor): block-type gutter menu, focus mode, and Markdown paste**
- **feat(stickers): per-tool "lousy" sticker under every tool**
- **chore(stickers): drop the orphaned flat "lousy" sticker**
- **feat(text-editor): selection bubble toolbar, session-only privacy, ghost placeholder**
- **chore(tools): keep "new" badge only on the 3 newest tools**
- **feat(colour): grid notation selector + show contrast colours in chosen notation**
- **feat(qr-generator): add WiFi QR code generation option with form**
- **feat(qr-generator): remove WiFi option from input placeholders**
- **fix(shavian-dict): change word variable to const to resolve lint errors**
- **feat(wifi-form): update security type options and adjust input types for WiFi form**
- **fix(qr-generator): decouple WiFi form state, harden WIFI string, add info captions on export**
- **fix(security): sandbox print iframe, self-host fonts/CSS, fix tool memory leaks**
- **chore(parity): record WiFi form + add-information export as web-only QR features**
- **feat(code-generator): toggleable HRI numbers + transparent PNG export**
- **feat(home): dense hairline redesign + iA Writer Quattro typeface**
- **feat(tools): flush segmented system + square corners; rework QR generator**
- **docs: DESIGN.md — dense/flush/hairline design system spec for tool rework**
- **feat(tools): dense/flush/hairline redesign across the tool catalogue**
- **feat(credits): add Val C (EFF) to donor thanks**
- **docs(parity): add Base64 Image Encoder row (web-only)**
- **feat(credits): add Muhammad Fikri to contributors**
- **feat: add base64 image encoder tool**
- **refactor: apply new dense/flush design system and add error boundaries**
- **feat(credits): add Carlos Araújo to donor thanks**
- **docs(substrata): add SPEC and milestone BUILD-PLAN; ignore /sketches**
- **refactor(app): split site chrome into (site) route group**
- **feat(substrata): scaffold sidebar-free /editor route + Fabric mount**
- **feat(substrata): persistence, capability + WebGL-guard scaffolding**
- **feat(substrata): pure colour libs + reusable social presets**
- **fix(substrata): read secure-context via useSyncExternalStore**
- **docs(parity): carve out Substrata as web-only / non-parity (M0-9)**
- **feat(substrata): default artboard 2000x1500 + artboard-preset type**
- **feat(substrata): layer-style family + registry (generalise drop shadow)**
- **refactor(substrata): rename styles[] → effects[] (filters in, effects out)**
- **feat(substrata): ratify doc-model schema v1**
- **feat(substrata): doc→Fabric reconciler + raster import (M1-3/M1-5)**
- **feat(substrata): layers panel — list, thumbnail, show/hide, select (M1-6)**
- **feat(substrata): MOVE tool — select, transform, clip-to-frame (M1-10)**
- **feat(substrata): undo/redo over the doc model (M1-8)**
- **feat(substrata): opt-in local persistence + autosave/restore (M1-9)**
- **feat(substrata): top bar (§7) — parity with mockup (M0-4/M0-5)**
- **feat(substrata): omnibar bar — tools cockpit + panels + overflow (M1-10/§8)**
- **feat(substrata): omnibar edge-docking + iconified Workspace menu**
- **feat(substrata): rail + pin-to-rail with open/close animations (§8)**
- **feat(substrata): module dock targets + left/right sidebars (§8 docking)**
- **feat(substrata): decouple rail from omnibar + wire Theme (§7 Workspace)**
- **feat(substrata): viewport/zoom + status toasts; STATE.md; spec toasts**
- **feat(substrata): inspector module + layout persistence + field maths**
- **feat(substrata): colour picker (7 modes + spectral EQ) + shared colour-field + inspector design pass**
- **feat(substrata): export/canvas-size modals + transparency checker + arrange + layers**
- **feat(substrata): FX module + contextual omnibar + multi-select/groups + snapping + MOVE chrome**
- **docs(substrata): ratify M2-1 schema extension (Ruby sign-off)**
- **feat(image-converter): swap AVIF output for JPEG XL (JXL)**
- **feat(substrata): M3 filters live (Tier-0 + Tier-1 shaders) + LOOKS module w/ film LUTs + layer/canvas context menu**
- **feat(substrata): M3 effects engine — effects[] renders via Canvas2D compositor in Fabric's object cache**
- **finish(substrata): simplify effects engine + review fixes (defaults merged upstream, pose self-dirty, dilate 25x->1x shadow renders)**
- **feat(substrata): PIECES primitives — 5 shapes drag-to-draw, ShapeLayer schema v2, settings bloom, shape chrome**
- **feat(substrata): after-the-fact shape params in Inspector + preset rows w/ custom (…) hatch (bloom + inspector)**
- **feat(substrata): Brush/Pencil freehand — perfect-freehand strokes, top-context preview, single-commit gesture**
- **fix(substrata): pencil streamline 0 (Ruby ratification — pencil follows the hand exactly)**
- **feat(substrata): M4 colour sink — picker recolours active shape/stroke + seeds next draws; Inspector fill/stroke rows**
- **feat(substrata): TEXT tool — system-stack fonts + FontFace upload, click-to-type IText editing, style presets (regular/outline/pill/rectangle)**
- **fix(substrata): text props apply mid-edit + exit commit adopts visual centre; font selector is a dropdown (Ruby)**
- **feat(substrata): M6 export pipeline — PNG/JPEG/WebP native + JXL worker, artboard/layer-solo scopes, area-clamp + verify + shrink-retry, live size estimate**
- **finish(substrata): simplify + review fixes for M6 export**
- **docs(substrata): ratify decision queue — SELECT scope/semantics, text-on-path cut, gallery source, M5 tuning, rulers+guides (Ruby 2026-07-07)**
- **feat(substrata): rulers + drag-out guides — sketch-faithful ruler bands, doc-model guides (undoable, autosaved, snappable), capture-phase gesture claim**
- **feat(substrata): SELECT tool — marquee/lasso(+magnetic)/wand pixel selections, extract/cut ops, contextual popup (M2-10, Ruby's 2026-07-07 ratifications)**
- **feat(substrata): Pieces preset-shape gallery — 19 Phosphor-fill symbols as drag-to-draw shapes (Ruby's 2026-07-07 ratification)**
- **feat(substrata): M5 persist core — .substrata save/open (fflate STORE zip, hash-verified blobs), Scene menu + keyboard file ops, recovery snapshots (Ruby's 2026-07-07 tuning)**
- **fix(substrata): SELECT adversarial-review fixes — 9 confirmed defects**
- **feat(substrata): text typography props + layers cross-parent drag + effective group opacity**
- **feat(substrata): M3-15 rasterize-layer command + cut the Bezier/pen stub (Ruby 2026-07-07)**
- **feat(substrata): guide gap-pills — mid-drag px distances to neighbour guides/artboard edges (backdrop-sketch chrome, destructive pills, tabular numerals)**
- **feat(substrata): gradient authoring UI — Solid/Gradient fill rows, stop editor, CSS-convention angle maths (M4 tail)**
- **feat(substrata): MOVE·Crop — non-destructive layer crop (Ruby's 2026-07-07 ratification)**
- **finish(substrata): simplify + review fixes across the day's eleven commits**
- **feat(substrata): M7 smarts + clarity fixes + drag-to-dock workspace (Ruby's 2026-07-08 ratifications)**
- **fix(substrata): bg-removal — pivot to the tool's proven RMBG-1.4 on transformers v3 (Ruby's call)**
- **feat(substrata): omnibar UX pass — flat tools, tool-settings module, big colour, dnd-kit docking (Ruby's asks)**
- **feat(substrata): omnibar four-unit layout — flush selections + inline tool settings (Ruby's follow-up)**
- **fix(substrata): omnibar settings unit back to a button — uniform bar height (Ruby)**
- **feat(substrata): omnibar middle unit = contextual trigger — subtool name + live chips (Ruby)**
- **feat(substrata): omnibar round-out — arrange inlined, shape flyouts, per-subtool shortcuts (Ruby)**
- **tweak(substrata): omnibar — primitives before pieces in the tools unit (Ruby)**
- **feat: add 'Delphi needs a favour' ticker + modal**
- **fix: min-w-0 on favour ticker so the marquee clips instead of widening the page**
- **fix: take favour marquee out of flow so it can't widen the page**
- **fix(substrata): silence ORT execution-provider warnings via session logSeverityLevel**
- **feat(substrata): touch-gesture resolution drop — 13→43fps on iPad + perf HUD**
- **feat(substrata): two-finger touch navigation — pan + pinch zoom (Procreate convention)**
- **feat(substrata): QOL four-pack — one-shot tools, New-scene dialog, storage intro, Help menu**
- **feat(substrata): onboarding flow, shared About-delphitools body, Feedback button**
- **feat(substrata): dismissible small-screen notice (sub-768px)**
- **tweak(substrata): small-screen notice centred, dismiss says 'all right all right' (Ruby)**
- **feat(substrata): doc-less boot — New-scene dialog gains an Add-image door**
- **feat(substrata): New-scene dialog split into a two-door chooser (Ruby)**
- **tweak(substrata): onboarding is one chrome-less box — no title bar, no X (Ruby)**
- **feat(substrata): onboarding copy written out — five slides + conditional touch slide**
- **feat(catalogue): Substrata joins the main delphitools page**
- **feat(home): Substrata billboard above the grid + sidebar item beside Home (Ruby)**
- **feat(substrata): Ruby's workshop illustration on onboarding slide 1**
- **feat(substrata): slide-2 illustration + delphi-clip pass on both onboarding images**
- **feat(substrata): slide-3 illustration — arrivals busy, departures cobwebbed**
- **feat(substrata): storage-slide sticker + Ruby's rewritten closing line**
- **feat(substrata): NOT FINISHED banner tops the beta send-off slide**
- **chore(substrata): Ruby's final copy fills + marker hygiene — slopsieve at zero**
- **chore: promote the verify suite to scripts/verify, clean the repo root**
- **feat: graffiti wordmark on the home billboard + tiled in the editor void**
- **feat(substrata): panels round 3 — free-floating mini panels with clamp (Ruby's spec)**
- **tweak(substrata): hold toggle uses lucide Pin/PinOff (Ruby: no hand-drawn icons)**
- **refactor(home): fold the Substrata billboard + Elsewhere cards into the tool grid (Ruby)**
- **feat(home): highlight treatment for Substrata's grid cell**
- **feat(substrata): click-to-rename the scene in the top bar**
- **feat(substrata): ADJUST quick presets — the tool's settings bloom does something**
- **tweak(substrata): ADJUST presets pass — Ruby's intro line + stacked cells**
- **chore: next 16.1.6 → 16.2.10 (+ eslint-config-next to match)**
- **fix(substrata): filter textureSize now MATCHES the import cap — looks square-cropped 4097–8192px rasters to 4096²**
- **feat(substrata): ⌘A selects unlocked artboard elements + menu keymap with hints (⌘E ⌘D ⌘G restack ⌘0/⌘1)**
- **fix(verify): layers-tree sample() settles two rAFs first — opacity checks raced the reconcile render (~50% flake)**
- **feat(tools): Image Stitcher — mosaic trail editor + batch grid**
- **chore(stickers): lousy stickers for Image Stitcher + Base64 Image Encoder (Ruby's art, delphi-clipped)**
- **feat(tools): Large Type — huge per-character transcription display**
- **docs(parity): flip iOS rows — image-stitcher ported, QR wifi/captions + barcode HRI/transparent landed**
- **feat(sidebar): sort tools alphabetically within categories (Greatest Hits untouched)**
- **feat(tools): colour blindness sim — tap/click image previews to expand in a lightbox**
- **fix(deploy): track package-lock.json to pin the Pages build**
- **feat(meta): OG share cards for every tool, Substrata and the home page**
- **feat(meta): og:image:alt copy for the three share cards**
- **feat: replace the Next app with the Ember rewrite**
- **Revert "chore: clear root markdown again, tighten gitignore" (markdown only)**
- **feat(about): cast section for Delphi, Alien Delphi, Emma and Vito**
- **feat(about): lay the cast out as a lineup rather than a stack**
- **feat(about): cast becomes an interactive lineup**
- **feat(about): pronouns into the lineup header, drop the blurb and heading**
- **feat(heroes): add Gooblin Arts, Ash Joseph and Missmaple**
- **fix(home): fit Greatest Hits into two rows, alien sticker on Experiments**
- **fix(ci): untrack bun.lock so CF Builds installs from package-lock.json**
- **fix: style changes**
- **fix(ci): wrangler config so the deploy uploads dist as worker assets**
- **chore: untrack the hero and art masters**
- **fix(favicon-genny): download every size as one zip**
- **feat(hero): add Art&Magic to the hero rotation**
- **fix(cast): rename the Alien Delphi asset off the ad slug**
- **fix(changelog): grey out tabs a release does not fill**
- **chore: 2.0.1**
- **fix(palette-collection): declare the colors query param**
- **fix(deploy): serve index.html for unmatched paths**
- **fix(omnibox): keep tool matches when an answer is present**
- **chore: 2.0.2**
- **fix(screen-recorder): correct cross-browser MediaRecorder and audio capture**
